### PR TITLE
prevent parent forms from being submitted when ENTER is pressed

### DIFF
--- a/d2l-input-search.html
+++ b/d2l-input-search.html
@@ -289,6 +289,7 @@ Polymer-based web component for search
 				if (e.keyCode !== this._keyCodes.ENTER) {
 					return;
 				}
+				e.preventDefault();
 				if (this.value !== this.lastSearchValue) {
 					this._setLastSearchValue(this.value);
 					this._dispatchEvent();


### PR DESCRIPTION
Without this, pressing ENTER in the search if it's contained in a parent `<form>` will result in the first button in the form (which could be the "clear" or "search" buttons of the search input!) being executed. Very, very weird to debug.