### PR TITLE
removing autofocus

### DIFF
--- a/d2l-input-search.html
+++ b/d2l-input-search.html
@@ -109,7 +109,6 @@ Polymer-based web component for search
 		<div class="d2l-input-search-container">
 			<input
 				aria-label$="[[label]]"
-				autofocus$="[[autofocus]]"
 				class="d2l-focusable"
 				disabled$="[[disabled]]"
 				maxlength$="[[maxlength]]"
@@ -151,12 +150,6 @@ Polymer-based web component for search
 			 */
 
 			properties: {
-				/**
-				 * Indicates that the input should have focus when the page loads.
-				 */
-				autofocus: {
-					type: Boolean
-				},
 				/**
 				 * Whether the input is disabled.
 				 */


### PR DESCRIPTION
Unfortunately, `autofocus` doesn't work consistently in browsers that don't natively support web components. MDN also warns that it's not super accessible to jump people into the input right away. I'll hack around this in MVC.