### PR TITLE
fixes #14: removes outline in Safari when focused

### DIFF
--- a/d2l-input-shared-styles.html
+++ b/d2l-input-shared-styles.html
@@ -52,6 +52,7 @@
 					background-color: var(--d2l-input-background-hover);
 					border-color: var(--d2l-color-celestine);
 					border-width: 2px;
+					outline-style: none;
 					outline-width: 0;
 					padding: var(--d2l-input-padding-focus);
 				};


### PR DESCRIPTION
Fixes this:

![screen shot 2018-08-30 at 4 37 29 pm](https://user-images.githubusercontent.com/5491151/44919724-2498b300-ad0c-11e8-9600-b700fda9973f.png)

This wasn't a bug with our inputs in the monolith because it includes a reset stylesheet that sets `outline: 0` on all elements.