### PR TITLE
putting line-height back

### DIFF
--- a/d2l-input-shared-styles.html
+++ b/d2l-input-shared-styles.html
@@ -7,6 +7,7 @@
 			:host {
 				--d2l-input-border-radius: 0.3rem;
 				--d2l-input-height: auto;
+				--d2l-input-line-height: 1.2rem;
 				--d2l-input-width: 100%;
 				--d2l-input-background-color: #ffffff;
 				--d2l-input-background-hover: inherit;
@@ -35,8 +36,9 @@
 					font-size: 0.8rem;
 					font-weight: 400;
 					letter-spacing: 0.02rem;
-					/* using min-height instead of line-height as IE11
+					/* using min-height and line-height as IE11
 					 * doesn't support line-height on inputs */
+					line-height: var(--d2l-input-line-height);
 					min-height: calc(2rem + 2px);
 				};
 				--d2l-input-textarea: {


### PR DESCRIPTION
Without the `line-height`, Safari text is misaligned by a couple pixels.

Before:
![screen shot 2018-08-31 at 11 48 16 am](https://user-images.githubusercontent.com/5491151/44922596-c96abe80-ad13-11e8-8566-e49f1c8982f2.png)

After:
![screen shot 2018-08-31 at 11 48 03 am](https://user-images.githubusercontent.com/5491151/44922611-d4bdea00-ad13-11e8-89bc-8d2d2b55eb2d.png)
