### PR TITLE
fixes #28: inherit isn't supported in mixins

### DIFF
--- a/d2l-input-shared-styles.html
+++ b/d2l-input-shared-styles.html
@@ -10,7 +10,6 @@
 				--d2l-input-line-height: 1.2rem;
 				--d2l-input-width: 100%;
 				--d2l-input-background-color: #ffffff;
-				--d2l-input-background-hover: inherit;
 				--d2l-input-border-color: var(--d2l-color-mica);
 				--d2l-input-boxshadow: inset 0 2px 0 0 rgba(185, 194, 208, .2);
 				--d2l-input-padding: 0.4rem 0.75rem;
@@ -52,7 +51,6 @@
 					padding: var(--d2l-input-padding);
 				};
 				--d2l-input-hover-focus: {
-					background-color: var(--d2l-input-background-hover);
 					border-color: var(--d2l-color-celestine);
 					border-width: 2px;
 					outline-style: none;


### PR DESCRIPTION
Specifying the background color on hover/focus wasn't needed anyway since it's already set on the input.