### PR TITLE
fixes #31: no need to include colors as they're global

### DIFF
--- a/d2l-input-shared-styles.html
+++ b/d2l-input-shared-styles.html
@@ -3,7 +3,7 @@
 
 <dom-module id="d2l-input-styles">
 	<template>
-		<style include="d2l-colors">
+		<style>
 			:host {
 				--d2l-input-border-radius: 0.3rem;
 				--d2l-input-height: auto;


### PR DESCRIPTION
Weirdly colors aren't a style module, they define the variables on the `html` element. So they don't need to be included.