### PR TITLE
Use hybrid vaadin-date-picker

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -31,7 +31,7 @@
     "iron-a11y-keys-behavior": "^2.1.1",
     "iron-input": "^2.1.3",
     "polymer": "Polymer/polymer#1 - 2",
-    "vaadin-date-picker": "Brightspace/vaadin-date-picker#1 - 2"
+    "vaadin-date-picker": "Brightspace/vaadin-date-picker#hybrid"
   },
   "devDependencies": {
     "d2l-typography": "BrightspaceUI/typography#^6.0.0",
@@ -43,8 +43,7 @@
   "variants": {
     "1.x": {
       "dependencies": {
-        "polymer": "Polymer/polymer#^1.0.0",
-        "vaadin-date-picker": "Brightspace/vaadin-date-picker#^1.2.8"
+        "polymer": "Polymer/polymer#^1.0.0"
       },
       "resolutions": {
         "webcomponentsjs": "^0.7"


### PR DESCRIPTION
Ok, so this is a temporary solution to the bower dependency issue with the `vaadin-date-picker`.  I've made a branch in our fork that is a true hybrid branch, based on an alpha release vaadin did before switching to full polymer 2 (they never had an official hybrid version).

Branch: https://github.com/Brightspace/vaadin-date-picker/compare/master...Brightspace:hybrid

I don't think this is a great solution (I only did basic regression testing, not all the vaadin tests pass, etc) but it does unblock us.  When someone actually uses this version of the date and datetime inputs we can revisit, but we may be moving to a new implementation entirely before that happens.

Thoughts?