### PR TITLE
Adding "no-clear" mode and always searching on-enter and on-search-press

### DIFF
--- a/d2l-input-search.html
+++ b/d2l-input-search.html
@@ -156,6 +156,12 @@ Polymer-based web component for search
 					type: Number
 				},
 				/**
+				 * When true, the clear button will not be displayed when a search is performed.
+				 */
+				noClear: {
+					type: Boolean
+				},
+				/**
 				 * A hint to the user of what can be entered in the input.
 				 */
 				placeholder: {
@@ -224,22 +230,22 @@ Polymer-based web component for search
 			 * Performs a search.
 			 */
 			search: function() {
-				if (this.value !== this.lastSearchValue) {
-					this._setLastSearchValue(this.value);
-					this._dispatchEvent();
-				}
+				var noClear = (this.noClear === true);
+				this._setLastSearchValue(this.value);
+				this._dispatchEvent();
 				fastdom.mutate(function() {
-					if (this.value.length > 0) {
+					if (!noClear && this.value.length > 0) {
 						Polymer.dom(this.root).querySelector('.d2l-input-search-clear').focus();
 					}
 				}.bind(this));
 			},
 
 			_computeShowSearch: function(lastSearchValue, value) {
+				var noClear = (this.noClear === true);
 				var valueIsEmpty = (value === undefined || value === null || value === '');
 				var lastSearchValueIsEmpty = (lastSearchValue === undefined || lastSearchValue === null || lastSearchValue === '');
 				var showSearch = (valueIsEmpty && lastSearchValueIsEmpty) ||
-					(lastSearchValue !== value);
+					(lastSearchValue !== value) || noClear;
 				return showSearch;
 			},
 
@@ -284,10 +290,8 @@ Polymer-based web component for search
 					return;
 				}
 				e.preventDefault();
-				if (this.value !== this.lastSearchValue) {
-					this._setLastSearchValue(this.value);
-					this._dispatchEvent();
-				}
+				this._setLastSearchValue(this.value);
+				this._dispatchEvent();
 			},
 
 			_handleInput: function(e) {

--- a/demo/d2l-input-search.html
+++ b/demo/d2l-input-search.html
@@ -46,6 +46,18 @@
 				</template>
 			</demo-snippet>
 
+			<h3>Search Input (No Clear)</h3>
+			<demo-snippet>
+				<template>
+					<d2l-input-search
+						label="Search"
+						value="Clear button will never appear"
+						placeholder="Search for some stuff"
+						no-clear>
+					</d2l-input-search>
+				</template>
+			</demo-snippet>
+
 		</div>
 		<script>
 			window.addEventListener('WebComponentsReady', function() {

--- a/test/d2l-input-search.html
+++ b/test/d2l-input-search.html
@@ -20,6 +20,11 @@
 				<d2l-input-search value="foo"></d2l-input-search>
 			</template>
 		</test-fixture>
+		<test-fixture id="no-clear">
+			<template>
+				<d2l-input-search value="foo" no-clear></d2l-input-search>
+			</template>
+		</test-fixture>
 		<script>
 			describe('<d2l-input-search>', function() {
 
@@ -85,6 +90,11 @@
 						assertSearchVisibility(elem, false);
 					});
 
+					it('should NOT show clear if value is set in no-clear mode', function() {
+						var elem = fixture('no-clear');
+						assertSearchVisibility(elem, true);
+					});
+
 					it('should show search if value is modified', function() {
 						var elem = fixture('value-set');
 						elem.value = 'foobar';
@@ -108,6 +118,13 @@
 						elem.value = 'foobar';
 						clickSearchButton(elem);
 						assertSearchVisibility(elem, false);
+					});
+
+					it('should NOT show clear if modified value is searched in no-clear mode', function() {
+						var elem = fixture('no-clear');
+						elem.value = 'foobar';
+						clickSearchButton(elem);
+						assertSearchVisibility(elem, true);
 					});
 
 				});
@@ -151,24 +168,6 @@
 						});
 						elem.value = '';
 						clickSearchButton(elem);
-					});
-
-					it('should not fire "search" event when ENTER is pressed with no value change', function(done) {
-						var elem = fixture('value-set');
-						elem.addEventListener('d2l-input-search-searched', function() {
-							throw 'Unexpected search event';
-						});
-						pressEnter(elem);
-						setTimeout(done, 50);
-					});
-
-					it('should not fire "search" event when search button is pressed on empty value', function(done) {
-						var elem = fixture('basic');
-						elem.addEventListener('d2l-input-search-searched', function() {
-							throw 'Unexpected search event';
-						});
-						clickSearchButton(elem);
-						setTimeout(done, 50);
 					});
 
 				});


### PR DESCRIPTION
Fixing `DE31437`. Changes two things:

1. Always performs a search when ENTER or the search button is pressed. This handles cases where we sometimes don't show anything until the user performs a search (including an empty search).

2. Adds the `no-clear` property that permanently disables the clear button, meaning the search button will always be there. This is for cases where the search input is just a small part of a larger advanced search scenario. In those cases the user may adjust advanced search options but not the search text itself, but still wants to see a search button to press to execute the search.