### PR TITLE
Add back old min-width

### DIFF
--- a/d2l-input-shared-styles.html
+++ b/d2l-input-shared-styles.html
@@ -22,7 +22,7 @@
 					box-sizing: border-box;
 					display: inline-block;
 					margin: 0;
-					min-width: 0;
+					min-width: calc(2rem + 1em);
 					vertical-align: middle;
 					width: var(--d2l-input-width);
 					transition: background-color 0.5s ease, border-color 0.5s ease;


### PR DESCRIPTION
Match min-width of old `text-input` (https://github.com/BrightspaceUI/text-input/blob/master/d2l-text-input-shared-styles.html#L21)