### PR TITLE
Mbayly/radio light dom

### DIFF
--- a/all-imports.html
+++ b/all-imports.html
@@ -1,5 +1,7 @@
 <link rel="import" href="d2l-input-checkbox.html">
 <link rel="import" href="d2l-input-checkbox-spacer.html">
+<link rel="import" href="d2l-input-radio-button.html">
+<link rel="import" href="d2l-input-radio-button-spacer.html">
 <link rel="import" href="d2l-input-search.html">
 <link rel="import" href="d2l-input-text.html">
 <link rel="import" href="d2l-input-textarea.html">

--- a/d2l-input-radio-button-spacer.html
+++ b/d2l-input-radio-button-spacer.html
@@ -1,0 +1,29 @@
+<link rel="import" href="../polymer/polymer.html">
+<!--
+`d2l-input-radio-button-spacer`
+Spacer to align secondary content with radio-button
+
+@demo demo/d2l-input-radio-button.html
+-->
+
+<dom-module id="d2l-input-radio-button-spacer">
+	<template strip-whitespace>
+		<style>
+			:host {
+				display: block;
+				padding-left: 1.7rem;
+				margin-bottom: 0.9rem;
+			}
+			:host-context([dir="rtl"]) {
+				padding-right: 1.7rem;
+				padding-left: 0;
+			}
+		</style>
+		<slot></slot>
+	</template>
+	<script>
+		Polymer({
+			is: 'd2l-input-radio-button-spacer'
+		});
+	</script>
+</dom-module>

--- a/d2l-input-radio-button-spacer.html
+++ b/d2l-input-radio-button-spacer.html
@@ -14,7 +14,12 @@ Spacer to align secondary content with radio-button
 				padding-left: 1.7rem;
 				margin-bottom: 0.9rem;
 			}
+			/* Do not combine these rtl styles. It seems to break Polymer 1/2 compatibility in IE/Edge */
 			:host-context([dir="rtl"]) {
+				padding-right: 1.7rem;
+				padding-left: 0;
+			}
+			:dir(rtl) {
 				padding-right: 1.7rem;
 				padding-left: 0;
 			}

--- a/d2l-input-radio-button.html
+++ b/d2l-input-radio-button.html
@@ -1,0 +1,192 @@
+<link rel="import" href="../polymer/polymer-element.html">
+<link rel="import" href="../d2l-colors/d2l-colors.html">
+<link rel="import" href="../d2l-typography/d2l-typography-shared-styles.html">
+
+<!--
+'d2l-input-radio-button'
+Polymer-based web component for D2L radio buttons
+
+@demo demo/d2l-input-radio-button.html
+-->
+
+<dom-module id="d2l-input-radio-button">
+	<template strip-whitespace>
+		<style>
+			:host {
+				display: block;
+				margin-bottom: 0.9rem;
+			}
+			:host([aria-label]) {
+				display: inline-block;
+				margin-bottom: 0;
+			}
+			label {
+				display: inline-block;
+				white-space: nowrap;
+			}
+			.d2l-input-radio-button-label {
+				@apply --d2l-body-compact-text;
+				color: var(--d2l-color-ferrite);
+				display: inline-block;
+				margin-left: 0.5rem;
+				vertical-align: middle;
+				white-space: normal;
+			}
+			:host-context([dir="rtl"]) .d2l-input-radio-button-label {
+				margin-left: 0;
+				margin-right: 0.5rem;
+			}
+			:host([aria-label]) .d2l-input-radio-button-label,
+			:host-context([dir="rtl"][aria-label]) .d2l-input-radio-button-label {
+				margin-left: 0;
+				margin-right: 0;
+			}
+			input[type="radio"] {
+				-webkit-appearance: none;
+				-moz-appearance: none;
+				appearance: none;
+				background-position: center center;
+				background-repeat: no-repeat;
+				background-size: 0.5rem 0.5rem;
+				border-radius: 50%;
+				border-style: solid;
+				box-sizing: border-box;
+				display: inline-block;
+				height: 1.2rem;
+				margin: 0;
+				padding: 0;
+				transition-duration: 0.5s;
+				transition-timing-function: ease;
+				transition-property: background-color, border-color;
+				vertical-align: middle;
+				width: 1.2rem;
+			}
+			input[type="radio"]:checked {
+				background-image: url("data:image/svg+xml,%3Csvg%20width%3D%2210%22%20height%3D%2210%22%20viewBox%3D%220%200%2010%2010%22%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%3E%0A%09%3Ccircle%20cx%3D%225%22%20cy%3D%225%22%20r%3D%225%22%20fill%3D%22%23565a5c%22%3E%3C/circle%3E%0A%3C/svg%3E");
+			}
+			input[type="radio"],
+			input[type="radio"]:hover:disabled {
+				background-color: var(--d2l-color-regolith);
+				border-color: var(--d2l-color-mica);
+				border-width: 1px;
+			}
+			input[type="radio"]:hover,
+			input[type="radio"]:focus,
+			input[type="radio"].d2l-radio-button-focus {
+				border-color: var(--d2l-color-celestine);
+				border-width: 2px;
+				outline-width: 0;
+			}
+			input[type="radio"][aria-invalid="true"] {
+				border-color: var(--d2l-color-cinnabar);
+			}
+			input[type="radio"]:disabled,
+			:host([disabled]) .d2l-radio-button-label {
+				opacity: 0.5;
+			}
+		</style>
+		<label>
+			<input
+				type="radio"
+				aria-label$="[[ariaLabel]]"
+				aria-labelledby$="[[ariaLabelledby]]"
+				checked="{{checked}}"
+				disabled$="[[disabled]]"
+				name$="[[name]]"
+				on-change="_handleChange"
+				on-focus="_handleFocus"
+				value$="[[value]]" />
+			<span class="d2l-input-radio-button-label"><slot></slot></span>
+		</label>
+	</template>
+	<script>
+		Polymer({
+			is: 'd2l-input-radio-button',
+			properties: {
+				/**
+				 * Fired when the checked state changes due to user interaction.
+				 *
+				 * @event change
+				*/
+				/**
+				 * Fired when the radio-button receives focus.
+				 *
+				 * @event focus
+				*/
+				/**
+				 * Gets or sets the [aria-label](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-label_attribute)
+				 * attribute, which defines a string label for the radio button. Must be used when
+				 * an explicit label (through child elements) isn't provided.
+				 */
+				ariaLabel: {
+					type: String,
+					reflectToAttribute: true
+				},
+				/**
+				 * Gets or sets the [aria-labelledby attribute](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-labelledby_attribute),
+				 * which contains the IDs of labels for the radio button.
+				 */
+				ariaLabelledby: {
+					type: String
+				},
+				/**
+				 * Gets or sets the state of the radio button, `true` is checked and `false` is unchecked.
+				 */
+				checked: {
+					type: Boolean,
+					reflectToAttribute: true,
+					value: false
+				},
+				/**
+				 * Gets or sets the disabled state of the radio button, `true` is disabled and `false` is enabled.
+				 */
+				disabled: {
+					type: Boolean,
+					reflectToAttribute: true,
+					value: false
+				},
+				/**
+				 * Gets or sets the radio name, "" by default.
+				 */
+				name: {
+					type: String,
+					reflectToAttribute: true,
+					value: ''
+				},
+				/**
+				 * Gets or sets the radio value that gets submitted in forms, "on" by default.
+				 */
+				value: {
+					type: String,
+					reflectToAttribute: true,
+					value: 'on'
+				}
+			},
+			focus: function() {
+				this.$$('input').focus();
+			},
+			_handleChange: function(e) {
+				this.checked = e.target.checked;
+
+				// in shady DOM the input's "change" event will leak through,
+				// so no need to fire it
+				if (Polymer.Element || Polymer.Settings.useShadow) {
+					this.dispatchEvent(new CustomEvent(
+						'change',
+						{bubbles: true, composed: false}
+					));
+				}
+			},
+			_handleFocus: function() {
+				// in shady DOM the input's "focus" event does not bubble,
+				// so no need to fire it
+				if (!Polymer.Settings.useShadow) {
+					this.dispatchEvent(new CustomEvent(
+						'focus',
+						{bubbles: true, composed: false}
+					));
+				}
+			}
+		});
+	</script>
+</dom-module>

--- a/d2l-input-radio-button.html
+++ b/d2l-input-radio-button.html
@@ -1,4 +1,4 @@
-<link rel="import" href="../polymer/polymer-element.html">
+<link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../d2l-colors/d2l-colors.html">
 <link rel="import" href="../d2l-typography/d2l-typography-shared-styles.html">
 
@@ -12,11 +12,11 @@ Polymer-based web component for D2L radio buttons
 <dom-module id="d2l-input-radio-button">
 	<template strip-whitespace>
 		<style>
-			:host {
+			.pseudo-host {
 				display: block;
 				margin-bottom: 0.9rem;
 			}
-			:host([aria-label]) {
+			.pseudo-host[has-aria-label] {
 				display: inline-block;
 				margin-bottom: 0;
 			}
@@ -32,12 +32,12 @@ Polymer-based web component for D2L radio buttons
 				vertical-align: middle;
 				white-space: normal;
 			}
-			:host-context([dir="rtl"]) .d2l-input-radio-button-label {
+			[dir="rtl"] .d2l-input-radio-button-label,
+			:dir(rtl) .d2l-input-radio-button-label {
 				margin-left: 0;
 				margin-right: 0.5rem;
 			}
-			:host([aria-label]) .d2l-input-radio-button-label,
-			:host-context([dir="rtl"][aria-label]) .d2l-input-radio-button-label {
+			.pseudo-host[has-aria-label] .d2l-input-radio-button-label {
 				margin-left: 0;
 				margin-right: 0;
 			}
@@ -81,23 +81,25 @@ Polymer-based web component for D2L radio buttons
 				border-color: var(--d2l-color-cinnabar);
 			}
 			input[type="radio"]:disabled,
-			:host([disabled]) .d2l-radio-button-label {
+			.pseudo-host[disabled] .d2l-input-radio-button-label {
 				opacity: 0.5;
 			}
 		</style>
-		<label>
-			<input
-				type="radio"
-				aria-label$="[[ariaLabel]]"
-				aria-labelledby$="[[ariaLabelledby]]"
-				checked="{{checked}}"
-				disabled$="[[disabled]]"
-				name$="[[name]]"
-				on-change="_handleChange"
-				on-focus="_handleFocus"
-				value$="[[value]]" />
-			<span class="d2l-input-radio-button-label"><slot></slot></span>
-		</label>
+		<div class="pseudo-host" has-aria-label$="[[ariaLabel]]" disabled$=[[disabled]]>
+			<label>
+				<input
+					type="radio"
+					aria-label$="[[ariaLabel]]"
+					aria-labelledby$="[[ariaLabelledby]]"
+					disabled$="[[disabled]]"
+					checked="[[checked]]"
+					name$="[[name]]"
+					on-change="_handleChange"
+					on-focus="_handleFocus"
+					value$="[[value]]" />
+				<span class="d2l-input-radio-button-label"><slot></slot></span>
+			</label>
+		</div>
 	</template>
 	<script>
 		Polymer({
@@ -131,10 +133,12 @@ Polymer-based web component for D2L radio buttons
 				},
 				/**
 				 * Gets or sets the state of the radio button, `true` is checked and `false` is unchecked.
+				 * IMPORTANT: This may not reflect the actual state of the underylying radio button if it
+				 * was changed in the background as a result of being part of a radio button group.
+				 * Use isChecked to get the value of the underlying radio button's checked property.
 				 */
 				checked: {
 					type: Boolean,
-					reflectToAttribute: true,
 					value: false
 				},
 				/**
@@ -162,8 +166,19 @@ Polymer-based web component for D2L radio buttons
 					value: 'on'
 				}
 			},
+			/**
+			 * Gets the check property of the underlying radio button
+			 */
+			get isChecked() {
+				try {
+					var c = this.querySelector('input').checked;
+					return c;
+				} catch (e) {
+					return false;
+				}
+			},
 			focus: function() {
-				this.$$('input').focus();
+				this.querySelector('input').focus();
 			},
 			_handleChange: function(e) {
 				this.checked = e.target.checked;
@@ -178,14 +193,12 @@ Polymer-based web component for D2L radio buttons
 				}
 			},
 			_handleFocus: function() {
-				// in shady DOM the input's "focus" event does not bubble,
-				// so no need to fire it
-				if (!Polymer.Settings.useShadow) {
-					this.dispatchEvent(new CustomEvent(
-						'focus',
-						{bubbles: true, composed: false}
-					));
-				}
+				// As this element is rendered into the light DOM we need to
+				// force it to fire focus events
+				this.dispatchEvent(new CustomEvent(
+					'focus',
+					{bubbles: true, composed: false}
+				));
 			},
 			_attachDom: function(dom) {
 				var slot = dom.querySelector('.d2l-input-radio-button-label');

--- a/d2l-input-radio-button.html
+++ b/d2l-input-radio-button.html
@@ -186,6 +186,13 @@ Polymer-based web component for D2L radio buttons
 						{bubbles: true, composed: false}
 					));
 				}
+			},
+			_attachDom: function(dom) {
+				var slot = dom.querySelector('.d2l-input-radio-button-label');
+				while (this.firstChild) {
+					slot.appendChild(this.firstChild);
+				}
+				this.appendChild(dom);
 			}
 		});
 	</script>

--- a/demo/d2l-input-radio-button-demo-component.html
+++ b/demo/d2l-input-radio-button-demo-component.html
@@ -1,0 +1,56 @@
+<link rel="import" href="../../polymer/polymer.html">
+<link rel="import" href="../d2l-input-radio-button.html">
+
+<!--
+`d2l-input-radio-button-demo-component`
+Demo component to act as a parent of radio buttons
+
+-->
+
+<dom-module id="d2l-input-radio-button-demo-component">
+	<template strip-whitespace>
+		<style>
+			:host {
+				display: block;
+			}
+
+			d2l-input-radio-button {
+				display: block;
+			}
+
+		</style>
+
+		<d2l-input-radio-button name="databind" checked>
+			<template is="dom-repeat" items="[[numbers]]">
+				<span>[[item]]</span>
+			</template>
+			Checked <b>bold</b> item
+		</d2l-input-radio-button>
+		<d2l-input-radio-button name="databind">Unchecked [[counter]] item</d2l-input-radio-button>
+		<button on-tap="increment">Increment</button>
+		<p>This is the counter value: [[counter]]</p>
+	</template>
+	<script>
+		Polymer({
+			is: 'd2l-input-radio-button-demo-component',
+			properties: {
+				counter: {
+					type: Number,
+					value: 0,
+				},
+				numbers: {
+					type: Array,
+					value: function() {
+						return [
+							1, 2, 3
+						];
+					}
+				}
+			},
+			increment: function() {
+				this.counter += 1;
+				this.push('numbers', this.counter);
+			}
+		});
+	</script>
+</dom-module>

--- a/demo/d2l-input-radio-button.html
+++ b/demo/d2l-input-radio-button.html
@@ -10,6 +10,7 @@
 		<link rel="import" href="../../d2l-typography/d2l-typography.html">
 		<link rel="import" href="../d2l-input-radio-button.html">
 		<link rel="import" href="../d2l-input-radio-button-spacer.html">
+		<link rel="import" href="./d2l-input-radio-button-demo-component.html">
 		<custom-style>
 			<style is="custom-style" include="demo-pages-shared-styles"></style>
 		</custom-style>
@@ -28,8 +29,8 @@
 			<h3>Simple radio button with label</h3>
 			<demo-snippet>
 				<template>
-					<d2l-input-radio-button checked>Checked item</d2l-input-radio-button>
-					<d2l-input-radio-button>Unchecked item</d2l-input-radio-button>
+					<d2l-input-radio-button name="options" checked>Checked <b>bold</b> item</d2l-input-radio-button>
+					<d2l-input-radio-button name="options">Unchecked item</d2l-input-radio-button>
 				</template>
 			</demo-snippet>
 
@@ -65,6 +66,13 @@
 						Additional content can go here and will<br>
 						also line up nicely with the radio button.
 					</d2l-input-radio-button-spacer>
+				</template>
+			</demo-snippet>
+
+			<h3>Radio button in a demo component</h3>
+			<demo-snippet>
+				<template>
+					<d2l-input-radio-button-demo-component></d2l-input-radio-button-demo-component>
 				</template>
 			</demo-snippet>
 

--- a/demo/d2l-input-radio-button.html
+++ b/demo/d2l-input-radio-button.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" dir="rtl">
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
@@ -21,6 +21,10 @@
 			html {
 				font-size: 20px;
 			}
+
+			d2l-input-radio-button {
+				display: block;
+			}
 		</style>
 	</head>
 	<body unresolved class="d2l-typography">
@@ -30,7 +34,7 @@
 			<demo-snippet>
 				<template>
 					<d2l-input-radio-button name="options" checked>Checked <b>bold</b> item</d2l-input-radio-button>
-					<d2l-input-radio-button name="options">Unchecked item</d2l-input-radio-button>
+					<d2l-input-radio-button name="options" value="off">Unchecked item</d2l-input-radio-button>
 				</template>
 			</demo-snippet>
 

--- a/demo/d2l-input-radio-button.html
+++ b/demo/d2l-input-radio-button.html
@@ -1,0 +1,73 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+		<title>d2l-inputs demo</title>
+		<script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+		<link rel="import" href="../../iron-demo-helpers/demo-pages-shared-styles.html">
+		<link rel="import" href="../../iron-demo-helpers/demo-snippet.html">
+		<link rel="import" href="../../d2l-typography/d2l-typography.html">
+		<link rel="import" href="../d2l-input-radio-button.html">
+		<link rel="import" href="../d2l-input-radio-button-spacer.html">
+		<custom-style>
+			<style is="custom-style" include="demo-pages-shared-styles"></style>
+		</custom-style>
+		<custom-style include="d2l-typography">
+			<style is="custom-style" include="d2l-typography"></style>
+		</custom-style>
+		<style>
+			html {
+				font-size: 20px;
+			}
+		</style>
+	</head>
+	<body unresolved class="d2l-typography">
+		<div class="vertical-section-container centered">
+
+			<h3>Simple radio button with label</h3>
+			<demo-snippet>
+				<template>
+					<d2l-input-radio-button checked>Checked item</d2l-input-radio-button>
+					<d2l-input-radio-button>Unchecked item</d2l-input-radio-button>
+				</template>
+			</demo-snippet>
+
+			<h3>Radio button with multi-line label</h3>
+			<demo-snippet>
+				<template>
+					<d2l-input-radio-button style="width:200px;">
+						Label for radio button that wraps nicely onto
+						multiple lines and stays aligned
+					</d2l-input-radio-button>
+				</template>
+			</demo-snippet>
+
+			<h3>Radio button with hidden label</h3>
+			<demo-snippet>
+				<template>
+					<d2l-input-radio-button aria-label="Label for radio button"></d2l-input-radio-button>
+				</template>
+			</demo-snippet>
+
+			<h3>Disabled radio button</h3>
+			<demo-snippet>
+				<template>
+					<d2l-input-radio-button checked disabled>Disabled radio button</d2l-input-radio-button>
+				</template>
+			</demo-snippet>
+
+			<h3>Radio button with label and secondary content</h3>
+			<demo-snippet>
+				<template>
+					<d2l-input-radio-button>Label for radio button</d2l-input-radio-button>
+					<d2l-input-radio-button-spacer style="color:#999999;">
+						Additional content can go here and will<br>
+						also line up nicely with the radio button.
+					</d2l-input-radio-button-spacer>
+				</template>
+			</demo-snippet>
+
+		</div>
+	</body>
+</html>

--- a/test/d2l-input-radio-button-test-component.html
+++ b/test/d2l-input-radio-button-test-component.html
@@ -1,0 +1,30 @@
+<link rel="import" href="../../polymer/polymer.html">
+<link rel="import" href="../d2l-input-radio-button.html">
+
+<!--
+`d2l-input-radio-button-test-component`
+Test component to act as a parent of radio buttons
+
+-->
+
+<dom-module id="d2l-input-radio-button-test-component">
+	<template strip-whitespace>
+		<style>
+			:host {
+				display: block;
+			}
+
+			d2l-input-radio-button {
+				display: block;
+			}
+		</style>
+		<div>Hello</div>
+		<d2l-input-radio-button name="test-group" checked></d2l-input-radio-button>
+		<d2l-input-radio-button name="test-group"></d2l-input-radio-button>
+	</template>
+	<script>
+		Polymer({
+			is: 'd2l-input-radio-button-test-component',
+		});
+	</script>
+</dom-module>

--- a/test/d2l-input-radio-button.html
+++ b/test/d2l-input-radio-button.html
@@ -134,7 +134,7 @@
 								expect(e.target.checked).to.equal(true);
 								elem.removeEventListener('change', listener);
 								done();
-							}
+							};
 							elem.addEventListener('change', listener);
 							MockInteractions.tap(input);
 						});

--- a/test/d2l-input-radio-button.html
+++ b/test/d2l-input-radio-button.html
@@ -1,0 +1,356 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+		<title>d2l-input-radio-button test</title>
+		<script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+		<script src="../../web-component-tester/browser.js"></script>
+		<link rel="import" href="../../iron-test-helpers/mock-interactions.html">
+		<link rel="import" href="../d2l-input-radio-button.html">
+		<link rel="import" href="./d2l-input-radio-button-test-component.html">
+	</head>
+	<body>
+		<test-fixture id="basic">
+			<template>
+				<d2l-input-radio-button label="basic"></d2l-input-radio-button>
+			</template>
+		</test-fixture>
+		<test-fixture id="checked">
+			<template>
+				<d2l-input-radio-button checked label="checked"></d2l-input-radio-button>
+			</template>
+		</test-fixture>
+		<test-fixture id="disabled">
+			<template>
+				<d2l-input-radio-button disabled label="disabled"></d2l-input-radio-button>
+			</template>
+		</test-fixture>
+		<test-fixture id="name-value">
+			<template>
+				<d2l-input-radio-button name="cb-name" value="cb-value" label="name-value"></d2l-input-radio-button>
+			</template>
+		</test-fixture>
+		<test-fixture id="group">
+			<template>
+				<d2l-input-radio-button-test-component></d2l-input-radio-button-test-component>
+			</template>
+		</test-fixture>
+		<script>
+			describe('d2l-input-radio-button', function() {
+
+				var elem;
+
+				describe('basic', function() {
+
+					it('should instantiate the element', function() {
+						elem = fixture('basic');
+						expect(elem.is).to.equal('d2l-input-radio-button');
+					});
+
+				});
+
+				describe('checked', function() {
+
+					describe('checked-false', function() {
+
+						beforeEach(function() {
+							elem = fixture('basic');
+						});
+
+						it('should default "checked" to false', function() {
+							expect(elem.checked).to.be.false;
+							expect(elem.hasAttribute('checked')).to.be.false;
+							expect(elem.querySelector('input').checked).to.be.false;
+						});
+
+						it('should reflect "checked" property change to input', function() {
+							elem.checked = true;
+							// expect(elem.hasAttribute('checked')).to.be.true;
+							expect(elem.querySelector('input').checked).to.be.true;
+						});
+
+						it('should reflect "checked" attribute change to property and input', function() {
+							elem.setAttribute('checked', 'checked');
+							expect(elem.checked).to.be.true;
+							expect(elem.querySelector('input').checked).to.be.true;
+						});
+
+						it('should reflect input "checked" change to property', function() {
+							elem.querySelector('input').click();
+							expect(elem.checked).to.be.true;
+							// expect(elem.hasAttribute('checked')).to.be.true;
+						});
+
+					});
+
+					describe('checked-true', function() {
+
+						beforeEach(function() {
+							elem = fixture('checked');
+						});
+
+						it('should default "checked" to true', function() {
+							expect(elem.checked).to.be.true;
+							expect(elem.hasAttribute('checked')).to.be.true;
+							expect(elem.querySelector('input').checked).to.be.true;
+						});
+
+						it('should reflect "checked" property change to input', function() {
+							elem.checked = false;
+							// expect(elem.hasAttribute('checked')).to.be.false;
+							expect(elem.querySelector('input').checked).to.be.false;
+						});
+
+						it('should reflect "checked" attribute change to property and input', function() {
+							elem.removeAttribute('checked');
+							expect(elem.checked).to.be.false;
+							expect(elem.querySelector('input').checked).to.be.false;
+						});
+					});
+
+					describe('checked-change-event', function() {
+
+						beforeEach(function() {
+							elem = fixture('basic');
+						});
+
+						it('should fire "change" event when input element is clicked', function(done) {
+							var input = elem.querySelector('input');
+							elem.addEventListener('change', function(e) {
+								if (Polymer.Element || Polymer.Settings.useShadow) {
+									expect(e.target).to.equal(elem);
+								} else {
+									expect(e.target).to.equal(input);
+								}
+								done();
+							});
+							MockInteractions.tap(input);
+						});
+
+						it('should reflect that a previously unchecked input is now checked', function(done) {
+							var input = elem.querySelector('input');
+							var listener = function(e) {
+								expect(e.target.checked).to.equal(true);
+								elem.removeEventListener('change', listener);
+								done();
+							}
+							elem.addEventListener('change', listener);
+							MockInteractions.tap(input);
+						});
+
+					});
+
+					describe('checked-group', function() {
+
+						beforeEach(function() {
+							elem = fixture('group');
+						});
+
+						it('should uncheck grouped button when other button clicked', function() {
+							var one = Polymer.dom(elem.root).querySelectorAll('d2l-input-radio-button')[0];
+							var two = Polymer.dom(elem.root).querySelectorAll('d2l-input-radio-button')[1];
+							expect(one.isChecked).to.be.true;
+							two.querySelector('input').click();
+							expect(one.isChecked).to.be.false;
+							expect(two.isChecked).to.be.true;
+						});
+					});
+				});
+
+				describe('disabled', function() {
+
+					describe('disabled-false', function() {
+
+						beforeEach(function() {
+							elem = fixture('basic');
+						});
+
+						it('should default "disabled" to false', function() {
+							expect(elem.disabled).to.be.false;
+							expect(elem.hasAttribute('disabled')).to.be.false;
+							expect(elem.querySelector('input').disabled).to.be.false;
+						});
+
+						it('should reflect "disabled" property change to attribute and input', function() {
+							elem.disabled = true;
+							expect(elem.hasAttribute('disabled')).to.be.true;
+							expect(elem.querySelector('input').disabled).to.be.true;
+						});
+
+						it('should reflect "disabled" attribute change to property and input', function() {
+							elem.setAttribute('disabled', 'disabled');
+							expect(elem.disabled).to.be.true;
+							expect(elem.querySelector('input').disabled).to.be.true;
+						});
+
+					});
+
+					describe('disabled-true', function() {
+
+						beforeEach(function() {
+							elem = fixture('disabled');
+						});
+
+						it('should default "disabled" to true', function() {
+							expect(elem.disabled).to.be.true;
+							expect(elem.hasAttribute('disabled')).to.be.true;
+							expect(elem.querySelector('input').disabled).to.be.true;
+						});
+
+						it('should reflect "disabled" property change to attribute and input', function() {
+							elem.disabled = false;
+							expect(elem.hasAttribute('disabled')).to.be.false;
+							expect(elem.querySelector('input').disabled).to.be.false;
+						});
+
+						it('should reflect "disabled" attribute change to property and input', function() {
+							elem.removeAttribute('disabled');
+							expect(elem.disabled).to.be.false;
+							expect(elem.querySelector('input').disabled).to.be.false;
+						});
+
+					});
+
+				});
+
+				describe('value', function() {
+
+					describe('default', function() {
+
+						beforeEach(function() {
+							elem = fixture('basic');
+						});
+
+						it('should default "value" to "on"', function() {
+							expect(elem.value).to.equal('on');
+							expect(elem.getAttribute('value')).to.equal('on');
+							expect(elem.querySelector('input').value).to.equal('on');
+						});
+
+						it('should reflect "value" property change to attribute and input', function() {
+							elem.value = 'new value';
+							expect(elem.getAttribute('value')).to.equal('new value');
+							expect(elem.querySelector('input').value).to.equal('new value');
+						});
+
+						it('should reflect "value" attribute change to property and input', function() {
+							elem.setAttribute('value', 'new value');
+							expect(elem.value).to.equal('new value');
+							expect(elem.querySelector('input').value).to.equal('new value');
+						});
+
+					});
+
+					describe('set', function() {
+
+						beforeEach(function() {
+							elem = fixture('name-value');
+						});
+
+						it('should default "value" to "cb-value"', function() {
+							expect(elem.value).to.equal('cb-value');
+							expect(elem.getAttribute('value')).to.equal('cb-value');
+							expect(elem.querySelector('input').value).to.equal('cb-value');
+						});
+
+						it('should reflect "value" property change to attribute and input', function() {
+							elem.value = 'new value';
+							expect(elem.getAttribute('value')).to.equal('new value');
+							expect(elem.querySelector('input').value).to.equal('new value');
+						});
+
+						it('should reflect "value" attribute change to property and input', function() {
+							elem.setAttribute('value', 'new value');
+							expect(elem.value).to.equal('new value');
+							expect(elem.querySelector('input').value).to.equal('new value');
+						});
+
+					});
+
+				});
+
+				describe('name', function() {
+
+					describe('default', function() {
+
+						beforeEach(function() {
+							elem = fixture('basic');
+						});
+
+						it('should default "name" to ""', function() {
+							expect(elem.name).to.equal('');
+							expect(elem.querySelector('input').name).to.equal('');
+							expect(elem.getAttribute('name')).to.equal('');
+						});
+
+						it('should reflect "name" property change to attribute and input', function() {
+							elem.name = 'new name';
+							expect(elem.getAttribute('name')).to.equal('new name');
+							expect(elem.querySelector('input').name).to.equal('new name');
+						});
+
+						it('should reflect "name" attribute change to property and input', function() {
+							elem.setAttribute('name', 'new name');
+							expect(elem.name).to.equal('new name');
+							expect(elem.querySelector('input').name).to.equal('new name');
+						});
+
+					});
+
+					describe('set', function() {
+
+						beforeEach(function() {
+							elem = fixture('name-value');
+						});
+
+						it('should default "name" to "cb-name"', function() {
+							expect(elem.name).to.equal('cb-name');
+							expect(elem.getAttribute('name')).to.equal('cb-name');
+							expect(elem.querySelector('input').name).to.equal('cb-name');
+						});
+
+						it('should reflect "name" property change to attribute and input', function() {
+							elem.name = 'new name';
+							expect(elem.getAttribute('name')).to.equal('new name');
+							expect(elem.querySelector('input').name).to.equal('new name');
+						});
+
+						it('should reflect "name" attribute change to property and input', function() {
+							elem.setAttribute('name', 'new name');
+							expect(elem.name).to.equal('new name');
+							expect(elem.querySelector('input').name).to.equal('new name');
+						});
+
+					});
+
+				});
+
+				describe('focus management', function() {
+
+					beforeEach(function() {
+						elem = fixture('basic');
+					});
+
+					it('should fire "focus" event when input element is focussed', function(done) {
+						elem.addEventListener('focus', function(e) {
+							expect(e.target).to.equal(elem);
+							done();
+						});
+						MockInteractions.focus(elem.querySelector('input'));
+					});
+
+					it('should fire "focus" event when custom element is focussed', function(done) {
+						elem.addEventListener('focus', function(e) {
+							expect(e.target).to.equal(elem);
+							done();
+						});
+						MockInteractions.focus(elem);
+					});
+
+				});
+
+			});
+		</script>
+	</body>
+</html>

--- a/test/index.html
+++ b/test/index.html
@@ -13,7 +13,7 @@
 				'd2l-input-checkbox.html?wc-shadydom=true&wc-ce=true',
 				'd2l-input-checkbox.html?dom=shadow',
 				'd2l-input-radio-button.html?wc-shadydom=true&wc-ce=true',
-				'd2l-input-radio-button.html?dom=shadow',
+				'd2l-input-radio-button.html',
 				'd2l-input-search.html?wc-shadydom=true&wc-ce=true',
 				'd2l-input-search.html?dom=shadow',
 				'd2l-input-text.html?wc-shadydom=true&wc-ce=true',

--- a/test/index.html
+++ b/test/index.html
@@ -12,6 +12,8 @@
 			WCT.loadSuites([
 				'd2l-input-checkbox.html?wc-shadydom=true&wc-ce=true',
 				'd2l-input-checkbox.html?dom=shadow',
+				'd2l-input-radio-button.html?wc-shadydom=true&wc-ce=true',
+				'd2l-input-radio-button.html?dom=shadow',
 				'd2l-input-search.html?wc-shadydom=true&wc-ce=true',
 				'd2l-input-search.html?dom=shadow',
 				'd2l-input-text.html?wc-shadydom=true&wc-ce=true',


### PR DESCRIPTION
This is an initial attempt at creating a `d2l-input-radio-button` component.

It's based off McLean's original d2l-radio-button work and the result of an email thread between Dave L, Dave B, McLean and myself on possible approaches for creating a web componentized radio button.

There are several limitations as described below, and I am coming around to thinking that we should either revert to just using a shared stylesheet (it used to be acceptable for `valence-ui-input`!) or we need to create a completely custom radio button/group component. (paper-radio-button does not use a native input) But let me know what you think.

The main goal of this implementation is to have a radio button component that encapsulates the styles associated with a radio button without requiring all users of radio buttons to have to import a shared stylesheet and apply additional classes to get appropriate styling on labels etc. But do so in such a way that the native browser radio button group functionality continues to work:
- keyboard accessibility (tab, arrow key)
- checking one button automatically unchecks other buttons in the group

The main barrier to getting this behavior in an encapsulated radio button, is that if each native radio button is under a different shadow root, then the browser will not consider them to be part of the same group.  So the strategy here is to utilize a Polymer feature `_attachDom(dom)` to override how the shadow root is setup on radio button components so that the radio button template is stamped into the light DOM of the parent component.

https://polymer-library.polymer-project.org/2.0/docs/devguide/dom-template#stamp-templates-in-light-dom

This initially looked liked a promising approach, but on implementation it became clear that using components in this way introduces a number of limitations which are described below. 

In addition and unrelated to the shadow DOM issues, the native radio button `checked` property behavior makes them difficult to use with a databinding system like Polymer, because when a grouped radio button becomes unchecked in response to another button becoming checked, no notifications/events are sent for the unchecked button, so it is not possible to maintain it's Polymer `checked` property/attribute value.  More on this issue below too.

### Light DOM limitations

**Slots not supported**

Cannot use slots when stamping template into light DOM. We use slots to distribute the radio button label. The workaround is to use DOM APIs to move the element children when the DOM is attached. See `d2l-input-radio-button-demo-component`. This seems to continue to support databinding, but may have limitations that I have not yet seen.

**Radio button style duplication**

Polymer recommend that templates stamped into the light DOM should not contain any style tags.
One of the main reasons for this seems to be that the style tag encapsulated by the radio button component becomes style declarations of the parent component. So if you have 6 radio buttons on a page, every radio button style will be duplicated 6 times and applied to every radio button. The styles basically just keep overriding each other, but the are all in scope.  This doesn't break but it might have performance implications particularly for a page with a lot of radio buttons?  It could be limited to a set of styles per radio group if we introduced a radio button group component that also used this light DOM approach.

**:host selector not available**

Because the component's template is stamped into the light DOM :host selectors don't work as expected. They cannot be used in combination with attributes on the radio button component, as the radio button's host is it's parent component.  They also leak into the parent component which could inadvertently style the parent. So they cannot be used.

A work around for the host attribute selector is to project the host attributes onto an internal div. (see `pseudo-host` in the radio button).

Another limitation is it's not possible to give the component a default style like `display: block` so all radio button components will be `display: inline` (even though there template might be `display: block` ) unless overridden by the parent component.  The same limitation makes it harder to override default styles like margins on a host. If a components default margins are moved from the :host selector to an internal div, then they cannot be overridden by parents without resorting to using selectors that dip into the component's internal styles. And this wouldn't work with shadyCSS due to style scoping polyfills.

**:host-context selector behavior changes**

The :host-context is the parent elements :host-context. If the radio button is used in a document rather than in another component it has no :host-context so selectors like `:host-context([dir="rtl"]) .d2l-input-radio-button-label` will not work.

The workaround is to double up such selectors with standard attribute selectors e.g.

```
[dir="rtl"] .d2l-input-radio-button-label,
:dir(rtl) .d2l-input-radio-button-label {
    margin-left: 0; 
    margin-right: 0.5rem;
}
```

**Things that still work!**

Surprisingly the following things which we thought might break still seem to work:

- ShadyCSS style scopes
- Polymer 1 behaviour unchanged because `_attachDom` is ignored in Polymer 1 (sidenote: but you cannot use shadow DOM in Chrome with Polymer 1!)
- Data binding of pseudo slotted content e.g. the label for the radio button, seems to continue to work, even when in a dom-repeat. This is presumably because we are just moving existing nodes, and all children are mutating within the context of these nodes. If there are scenarios where the top level pseudo slotted child elements change it will likely break.

### General Radio Button Limitations

The radio button component was originally modeled after the d2l-input-checkbox. That component includes a Polymer `checked` property that stays synced with the underlying native checkbox `checked` property and also reflects to the d2l-input-checkbox `checked` attribute.

However, it was not possible to duplicate this behaviour with a group radio button.  This is because if a grouped radio button becomes unchecked due to checking a different button, there are no notifications or events so the Polymer `checked` property doesn't correctly reflect the underlying radio button property.

I tried to workaround this by adding custom `checked` property setter/getter accessors that explicitly set/get the underlying radio button `checked` property. However, this seemed to interfere with the accessors created by Polymer and in particular with the attribute to property mapping that Polymer does.

The component is still usable, particularly if the user of the component just relies on the change notifications of the last selected button to track the state (which is what you would do with native radio buttons anyway). However, I thought it could be confusing that you could call `myButton.checked` and get a result of `true` for a button that is actually unchecked. So as a pretty poor workaround, I've added a custom `isChecked` property get accessor that gets the `checked` status of the underlying native radio button which user's would use instead of the 'checked' property.  So the 'checked' attribute/property is only really used for the initial state. This is somewhat similar to the `checked` attribute behavior of native radio buttons which don't reflect their `checked` property value to their attribute either. But the lack of syncing of the `checked` property is pretty ugly.

### Next Steps

That's it. I'm going to take a 'copy' of this component, rename it and use it in rubrics, to see if using it for real throws up any other issues, particularly around managing state.  In the meantime we can decide if we want to run with this strategy or go back to another option. e.g. shared style sheet.