### PR TITLE
add style module for radio button styles

### DIFF
--- a/d2l-input-radio-styles.html
+++ b/d2l-input-radio-styles.html
@@ -1,0 +1,93 @@
+<link rel="import" href="../../polymer/polymer.html">
+<link rel="import" href="../../d2l-colors/d2l-colors.html">
+<link rel="import" href="../../d2l-typography/d2l-typography-shared-styles.html">
+
+<!--
+'d2l-input-radio-styles'
+Styles for radio button
+
+@demo demo/d2l-input-radio-styles.html
+-->
+
+<dom-module id="d2l-input-radio-styles">
+	<template strip-whitespace>
+		<style>
+			.d2l-input-radio-label {
+				display: flex;
+				align-items: center;
+				padding-left: 1.7rem;
+				padding-right: 0;
+				vertical-align: middle;
+				@apply --d2l-body-compact-text;
+				color: var(--d2l-color-ferrite);
+				margin-bottom: 0.9rem;
+			}
+			.d2l-input-radio-label.disabled {
+				opacity: 0.5;
+			}
+			.d2l-input-radio-label.disabled > input[type="radio"] {
+				opacity: 1.0;
+			}
+			.d2l-input-radio-label:last-of-type {
+				margin-bottom: 0;
+			}
+			.d2l-input-radio-label > input[type="radio"] {
+				margin-right: 0.5rem;
+				margin-left: -1.7rem;
+				flex: 0 0 auto;
+			}
+			[dir="rtl"] .d2l-input-radio-label,
+			:dir(rtl) .d2l-input-radio-label {
+				padding-right: 1.7rem;
+				padding-left: 0;
+			}
+			[dir="rtl"] .d2l-input-radio-label > input[type="radio"],
+			:dir(rtl) .d2l-input-radio-label > input[type="radio"] {
+				margin-left: 0.5rem;
+				margin-right: -1.7rem;
+			}
+			input[type="radio"] {
+				-webkit-appearance: none;
+				-moz-appearance: none;
+				appearance: none;
+				background-position: center center;
+				background-repeat: no-repeat;
+				background-size: 0.5rem 0.5rem;
+				border-radius: 50%;
+				border-style: solid;
+				box-sizing: border-box;
+				display: inline-block;
+				height: 1.2rem;
+				margin: 0;
+				padding: 0;
+				transition-duration: 0.5s;
+				transition-timing-function: ease;
+				transition-property: background-color, border-color;
+				vertical-align: middle;
+				width: 1.2rem;
+			}
+			input[type="radio"]:checked {
+				background-image: url("data:image/svg+xml,%3Csvg%20width%3D%2210%22%20height%3D%2210%22%20viewBox%3D%220%200%2010%2010%22%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%3E%0A%09%3Ccircle%20cx%3D%225%22%20cy%3D%225%22%20r%3D%225%22%20fill%3D%22%23565a5c%22%3E%3C/circle%3E%0A%3C/svg%3E");
+			}
+			input[type="radio"],
+			input[type="radio"]:hover:disabled {
+				background-color: var(--d2l-color-regolith);
+				border-color: var(--d2l-color-mica);
+				border-width: 1px;
+			}
+			input[type="radio"]:hover,
+			input[type="radio"]:focus,
+			input[type="radio"].d2l-radio-button-focus {
+				border-color: var(--d2l-color-celestine);
+				border-width: 2px;
+				outline-width: 0;
+			}
+			input[type="radio"][aria-invalid="true"] {
+				border-color: var(--d2l-color-cinnabar);
+			}
+			input[type="radio"]:disabled {
+				opacity: 0.5;
+			}
+		</style>
+	</template>
+</dom-module>

--- a/demo/d2l-input-radio-styles.html
+++ b/demo/d2l-input-radio-styles.html
@@ -1,0 +1,90 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+		<title>d2l-inputs demo</title>
+		<script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+		<link rel="import" href="../../iron-demo-helpers/demo-pages-shared-styles.html">
+		<link rel="import" href="../../iron-demo-helpers/demo-snippet.html">
+		<link rel="import" href="../../d2l-typography/d2l-typography.html">
+		<link rel="import" href="../d2l-input-radio-styles.html">
+		<custom-style>
+			<style is="custom-style" include="demo-pages-shared-styles"></style>
+		</custom-style>
+		<custom-style include="d2l-typography">
+			<style is="custom-style" include="d2l-typography"></style>
+		</custom-style>
+		<custom-style include="d2l-input-radio-styles">
+			<style is="custom-style" include="d2l-input-radio-styles"></style>
+		</custom-style>
+		<style>
+			html {
+				font-size: 20px;
+			}
+		</style>
+	</head>
+	<body unresolved class="d2l-typography">
+		<div class="vertical-section-container centered">
+
+			<h3>Simple radio button with label</h3>
+			<demo-snippet>
+				<template>
+					<label class="d2l-input-radio-label">
+						<input name="ex1" type="radio" checked>Checked item
+					</label>
+					<label class="d2l-input-radio-label">
+						<input name="ex1" type="radio">Unchecked item
+					</label>
+
+				</template>
+			</demo-snippet>
+
+			<h3>Radio button with multi-line label</h3>
+			<demo-snippet>
+				<template>
+					<label class="d2l-input-radio-label" style="width:200px;">
+						<input name="ex2" type="radio" checked>
+						Label for radio button that wraps nicely onto
+						multiple lines and stays aligned
+					</label>
+					<label class="d2l-input-radio-label" style="width:200px;">
+						<input name="ex2" type="radio">
+						And this is another label that will also wrap
+						onto additional lines
+					</label>
+				</template>
+			</demo-snippet>
+
+			<h3>Radio button with hidden label</h3>
+			<demo-snippet>
+				<template>
+					<input name="ex3" type="radio" checked aria-label="Label for radio button 1">
+					<br/>
+					<input name="ex3" type="radio" aria-label="Label for radio button 2">
+				</template>
+			</demo-snippet>
+
+			<h3>Disabled radio button</h3>
+			<demo-snippet>
+				<template>
+					<label class="d2l-input-radio-label disabled">
+						<input name="ex4" type="radio" checked disabled>Checked item
+					</label>
+					<label class="d2l-input-radio-label disabled">
+						<input name="ex4" type="radio" disabled>Unchecked item
+					</label>
+				</template>
+			</demo-snippet>
+
+			<h3>Disabled radio button with hidden label</h3>
+			<demo-snippet>
+				<template>
+					<input name="ex5" type="radio" checked disabled aria-label="Label for radio button 1">
+					<br/>
+					<input name="ex5" type="radio" checked disabled aria-label="Label for radio button 2">
+				</template>
+			</demo-snippet>
+		</div>
+	</body>
+</html>


### PR DESCRIPTION
Based on our discussions on the pros/cons of using a web component for radio buttons, I created this simple style module that incorporates some of the styles that McLean had added to his component, and also copies styles from the old vui-input where those wouldn't work.

Feel free to decide not to accept the PR if you think we should wait for a more Polymer 3-ish plain jane css stylesheet.

We are using a local copy of this stylesheet in rubrics for the time being so that we could move forward with our feature.

I'm not entirely clear if the fancy negative margin stuff from vui-input is needed still or if there is a simpler approach, but left as is due to no more time left for this.

I also set the parent `<label>` class to `display: flex` to help with multi-line label alignment.

I wasn't entirely sure on how best to handle the `disabled` styling for the labels. That's one thing the web component approach definitely makes nicer as you only have a single `disabled` attribute. I found that setting an `opacity: 0.5` on the parent `<label>` as well as on the `<input>`, made the input have an opacity of `0.25` so I had to add css to reset a child input to `1.0`. Maybe there is a nicer approach to handle this. Open to suggestions.

