### PR TITLE
fix incorrect paths

### DIFF
--- a/d2l-input-radio-styles.html
+++ b/d2l-input-radio-styles.html
@@ -1,6 +1,6 @@
-<link rel="import" href="../../polymer/polymer.html">
-<link rel="import" href="../../d2l-colors/d2l-colors.html">
-<link rel="import" href="../../d2l-typography/d2l-typography-shared-styles.html">
+<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../d2l-colors/d2l-colors.html">
+<link rel="import" href="../d2l-typography/d2l-typography-shared-styles.html">
 
 <!--
 'd2l-input-radio-styles'


### PR DESCRIPTION
I screwed up the paths (extra folder level) when copying the stylesheet from rubrics. Things looked fine on the demo page because the dependencies were resolved correctly by the demo page, but breaks if you try and use the stylesheet in BSI.