### PR TITLE
fix scroll always showing in ie11

### DIFF
--- a/d2l-input-textarea.html
+++ b/d2l-input-textarea.html
@@ -67,6 +67,7 @@ Custom property | Description | Default
 				font-family: inherit;
 				line-height: inherit;
 				text-align: inherit;
+				overflow: hidden;
 			}
 
 			:host([no-border]) textarea.d2l-input,

--- a/d2l-input-textarea.html
+++ b/d2l-input-textarea.html
@@ -67,7 +67,7 @@ Custom property | Description | Default
 				font-family: inherit;
 				line-height: inherit;
 				text-align: inherit;
-				overflow: hidden;
+				overflow: auto;
 			}
 
 			:host([no-border]) textarea.d2l-input,


### PR DESCRIPTION
Fixes vertical scroll always showing in IE11
![image](https://user-images.githubusercontent.com/1471557/51133562-345ff200-17ea-11e9-9ce9-dd3f0b80c607.png)
