### PR TITLE
fix invalid border not showing

### DIFF
--- a/d2l-input-shared-styles.js
+++ b/d2l-input-shared-styles.js
@@ -2,7 +2,7 @@ import '@polymer/polymer/polymer-legacy.js';
 import 'd2l-colors/d2l-colors.js';
 const $_documentContainer = document.createElement('template');
 
-$_documentContainer.innerHTML = `<dom-module id="d2l-input-styles">
+$_documentContainer.innerHTML = /*html*/`<dom-module id="d2l-input-styles">
 	<template>
 		<style>
 			:host {
@@ -17,9 +17,11 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-input-styles">
 				--d2l-input-padding-focus: calc(0.4rem - 1px) calc(0.75rem - 1px);
 				--d2l-input-color: var(--d2l-color-ferrite);
 				--d2l-input-placeholder-color: var(--d2l-color-mica);
+
 				--d2l-input-common: {
 					border-radius: var(--d2l-input-border-radius);
 					border-style: solid;
+					border-color: var(--d2l-input-border-color);
 					box-sizing: border-box;
 					display: inline-block;
 					margin: 0;
@@ -116,12 +118,14 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-input-styles">
 			textarea.d2l-input:hover, textarea.d2l-input:focus {
 				@apply --d2l-input-hover-focus;
 			}
-			input.d2l-input[aria-invalid='true'],
+			input[aria-invalid="true"].d2l-input,
+			input[aria-invalid="true"].d2l-input:hover,
+			input[aria-invalid="true"].d2l-input:focus,
 			input[type="text"].d2l-input:invalid, input[type="search"].d2l-input:invalid,
 			input[type="tel"].d2l-input:invalid, input[type="url"].d2l-input:invalid,
 			input[type="email"].d2l-input:invalid, input[type="password"].d2l-input:invalid,
 			input[type="number"].d2l-input:invalid,
-			textarea.d2l-input[aria-invalid='true'], textarea.d2l-input:invalid {
+			textarea[aria-invalid='true'].d2l-input, textarea.d2l-input:invalid {
 				@apply --d2l-input-invalid;
 			}
 			input[type="text"].d2l-input:hover:disabled, input[type="search"].d2l-input:hover:disabled,

--- a/d2l-input-text.js
+++ b/d2l-input-text.js
@@ -18,7 +18,7 @@ import './d2l-input-shared-styles.js';
 import { Polymer } from '@polymer/polymer/lib/legacy/polymer-fn.js';
 const $_documentContainer = document.createElement('template');
 
-$_documentContainer.innerHTML = `<dom-module id="d2l-input-text">
+$_documentContainer.innerHTML = /*html*/`<dom-module id="d2l-input-text">
 	<template strip-whitespace="">
 		<style include="d2l-input-styles">
 			:host {
@@ -30,7 +30,30 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-input-text">
 				font-family: inherit;
 			}
 		</style>
-		<input aria-invalid$="[[ariaInvalid]]" aria-label$="[[ariaLabel]]" aria-labelledby$="[[ariaLabelledby]]" autofocus$="[[autofocus]]" class="d2l-input d2l-focusable" disabled$="[[disabled]]" list$="[[list]]" max$="[[max]]" maxlength$="[[maxlength]]" min$="[[min]]" minlength$="[[minlength]]" name$="[[name]]" on-change="_handleChange" on-keypress="_handleKeypress" pattern$="[[pattern]]" placeholder$="[[placeholder]]" readonly$="[[readonly]]" required$="[[required]]" size$="[[size]]" step$="[[step]]" tabindex$="[[tabIndex]]" type$="[[type]]" value="{{value::input}}">
+		<input
+			aria-invalid$="[[ariaInvalid]]"
+			aria-label$="[[ariaLabel]]"
+			aria-labelledby$="[[ariaLabelledby]]"
+			autofocus$="[[autofocus]]"
+			class="d2l-input d2l-focusable"
+			disabled$="[[disabled]]"
+			list$="[[list]]"
+			max$="[[max]]"
+			maxlength$="[[maxlength]]"
+			min$="[[min]]"
+			minlength$="[[minlength]]"
+			name$="[[name]]"
+			on-change="_handleChange"
+			on-keypress="_handleKeypress"
+			pattern$="[[pattern]]"
+			placeholder$="[[placeholder]]"
+			readonly$="[[readonly]]"
+			required$="[[required]]"
+			size$="[[size]]"
+			step$="[[step]]"
+			tabindex$="[[tabIndex]]"
+			type$="[[type]]"
+			value="{{value::input}}">
 	</template>
 
 </dom-module>`;

--- a/demo/d2l-input-text.html
+++ b/demo/d2l-input-text.html
@@ -51,7 +51,7 @@ document.body.appendChild($_documentContainer.content);
 		<script type="module">
 const $_documentContainer = document.createElement('template');
 
-$_documentContainer.innerHTML = `<div class="vertical-section-container centered">
+$_documentContainer.innerHTML = /*html*/`<div class="vertical-section-container centered">
 			<h3>Simple</h3>
 			<demo-snippet>
 				<template>
@@ -77,6 +77,13 @@ $_documentContainer.innerHTML = `<div class="vertical-section-container centered
 			<demo-snippet>
 				<template>
 					<d2l-input-text type="email" value="foo@"></d2l-input-text>
+				</template>
+			</demo-snippet>
+
+			<h3>Aria-Invalid</h3>
+			<demo-snippet>
+				<template>
+					<d2l-input-text type="text" aria-invalid="true"></d2l-input-text>
 				</template>
 			</demo-snippet>
 		</div>`;


### PR DESCRIPTION
Fixes https://trello.com/c/g4g2Xqpu/151-ui-rubrics-invalid-fields-do-not-have-a-red-border-works-in-chrome-seems-to-be-broken-everywhere-else

Red border was not showing on browsers other than Chrome. Also in Chrome, it was turning blue on hover even when invalid.