### PR TITLE
Dkarras/us104007

### DIFF
--- a/d2l-input-checkbox.js
+++ b/d2l-input-checkbox.js
@@ -105,7 +105,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-input-checkbox">
 			}
 		</style>
 		<label>
-			<input type="checkbox" class$="[[_getInputClass(tri)]]" aria-label$="[[ariaLabel]]" aria-labelledby$="[[ariaLabelledby]]" checked="{{checked}}" disabled$="[[disabled]]" name$="[[name]]" on-change="_handleChange" on-focus="_handleFocus" value$="[[value]]">
+			<input type="checkbox" class$="[[_getInputClass(tri)]]" aria-label$="[[ariaLabel]]" aria-labelledby$="[[ariaLabelledby]]" checked="{{checked}}" disabled$="[[disabled]]" name$="[[name]]" on-change="_handleChange" on-click="_onClick" on-focus="_handleFocus" value$="[[value]]">
 			<span class="d2l-input-checkbox-label"><slot></slot></span>
 		</label>
 	</template>
@@ -197,6 +197,17 @@ Polymer({
 			{bubbles: true, composed: false}
 		));
 	},
+	_onClick: function(e) {
+		const browserType = window.navigator.userAgent;
+		if ( this.indeterminate && (browserType.indexOf('Trident') > -1 || browserType.indexOf('Edge') > -1)) {
+			this.checked = !this.checked;
+			this.indeterminate = false;
+			this.dispatchEvent(new CustomEvent(
+				'change',
+				{bubbles: true, composed: false}
+			));
+		}
+	},
 	_handleFocus: function() {
 		// in shady DOM the input's "focus" event does not bubble,
 		// so no need to fire it
@@ -215,15 +226,6 @@ Polymer({
 		} else {
 			elem.indeterminate = false;
 			elem.removeAttribute('aria-checked');
-		}
-		console.log(this.indeterminate);
-		const browserType = window.navigator.userAgent;
-		if (this.indeterminate && (browserType.indexOf('Trident') > -1 || browserType.indexOf('Edge') > -1)) {
-			console.log('in here');
-			this.dispatchEvent(new CustomEvent(
-				'change',
-				{bubbles: true, composed: false}
-			));
 		}
 	}
 });

--- a/d2l-input-checkbox.js
+++ b/d2l-input-checkbox.js
@@ -79,6 +79,9 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-input-checkbox">
 			input[type="checkbox"]:checked {
 				background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20width%3D%2224%22%20height%3D%2224%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22%23565A5C%22%20d%3D%22M8.4%2016.6c.6.6%201.5.6%202.1%200l8-8c.6-.6.6-1.5%200-2.1-.6-.6-1.5-.6-2.1%200l-6.9%207-1.9-1.9c-.6-.6-1.5-.6-2.1%200-.6.6-.6%201.5%200%202.1l2.9%202.9z%22/%3E%3C/svg%3E%0A");
 			}
+			input[type="checkbox"].tri {
+				background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20width%3D%2224%22%20height%3D%2224%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22%23565A5C%22%20d%3D%22M7.5%2C11h9c0.8%2C0%2C1.5%2C0.7%2C1.5%2C1.5l0%2C0c0%2C0.8-0.7%2C1.5-1.5%2C1.5h-9C6.7%2C14%2C6%2C13.3%2C6%2C12.5l0%2C0%0A%09C6%2C11.7%2C6.7%2C11%2C7.5%2C11z%22/%3E%3C/svg%3E%0A");
+			}
 			input[type="checkbox"],
 			input[type="checkbox"]:hover:disabled {
 				background-color: var(--d2l-color-regolith);
@@ -102,7 +105,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-input-checkbox">
 			}
 		</style>
 		<label>
-			<input type="checkbox" aria-label$="[[ariaLabel]]" aria-labelledby$="[[ariaLabelledby]]" checked="{{checked}}" disabled$="[[disabled]]" name$="[[name]]" on-change="_handleChange" on-focus="_handleFocus" value$="[[value]]">
+			<input type="checkbox" class$="[[_getInputClass(tri)]]" aria-label$="[[ariaLabel]]" aria-labelledby$="[[ariaLabelledby]]" checked="{{checked}}" disabled$="[[disabled]]" name$="[[name]]" on-change="_handleChange" on-focus="_handleFocus" value$="[[value]]">
 			<span class="d2l-input-checkbox-label"><slot></slot></span>
 		</label>
 	</template>
@@ -145,6 +148,14 @@ Polymer({
 		 * Gets or sets the state of the checkbox, `true` is checked and `false` is unchecked.
 		 */
 		checked: {
+			type: Boolean,
+			reflectToAttribute: true,
+			value: false
+		},
+		/**
+		 * Gets or sets the state of the checkbox, `true` is tri-state and `false` other.
+		 */
+		tri: {
 			type: Boolean,
 			reflectToAttribute: true,
 			value: false
@@ -193,5 +204,8 @@ Polymer({
 				{bubbles: true, composed: false}
 			));
 		}
+	},
+	_getInputClass: function(tri) {
+		return tri ? 'tri' : '';
 	}
 });

--- a/d2l-input-checkbox.js
+++ b/d2l-input-checkbox.js
@@ -198,8 +198,8 @@ Polymer({
 		));
 	},
 	/**
-	 * This is needed only for IE11 and Edge AND going from indeterminate to checked/unchecked. 
-	 * When the indeterminate state is set, and the checkbox is clicked, the _handleChange 
+	 * This is needed only for IE11 and Edge AND going from indeterminate to checked/unchecked.
+	 * When the indeterminate state is set, and the checkbox is clicked, the _handleChange
 	 * function is NOT triggered, therefore we have to detect the click and handle it ourselves.
 	 */
 	_handleClick: function() {

--- a/d2l-input-checkbox.js
+++ b/d2l-input-checkbox.js
@@ -79,7 +79,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-input-checkbox">
 			input[type="checkbox"]:checked {
 				background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20width%3D%2224%22%20height%3D%2224%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22%23565A5C%22%20d%3D%22M8.4%2016.6c.6.6%201.5.6%202.1%200l8-8c.6-.6.6-1.5%200-2.1-.6-.6-1.5-.6-2.1%200l-6.9%207-1.9-1.9c-.6-.6-1.5-.6-2.1%200-.6.6-.6%201.5%200%202.1l2.9%202.9z%22/%3E%3C/svg%3E%0A");
 			}
-			input[type="checkbox"].tri {
+			input[type="checkbox"]:indeterminate {
 				background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20width%3D%2224%22%20height%3D%2224%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22%23565A5C%22%20d%3D%22M7.5%2C11h9c0.8%2C0%2C1.5%2C0.7%2C1.5%2C1.5l0%2C0c0%2C0.8-0.7%2C1.5-1.5%2C1.5h-9C6.7%2C14%2C6%2C13.3%2C6%2C12.5l0%2C0%0A%09C6%2C11.7%2C6.7%2C11%2C7.5%2C11z%22/%3E%3C/svg%3E%0A");
 			}
 			input[type="checkbox"],
@@ -155,10 +155,11 @@ Polymer({
 		/**
 		 * Gets or sets the state of the checkbox, `true` is tri-state and `false` other.
 		 */
-		tri: {
+		indeterminate: {
 			type: Boolean,
 			reflectToAttribute: true,
-			value: false
+			value: false,
+			observer: '_setIndeterminate'
 		},
 		/**
 		 * Gets or sets the disabled state of the checkbox, `true` is disabled and `false` is enabled.
@@ -190,6 +191,7 @@ Polymer({
 	},
 	_handleChange: function(e) {
 		this.checked = e.target.checked;
+		this.indeterminate = false;
 		this.dispatchEvent(new CustomEvent(
 			'change',
 			{bubbles: true, composed: false}
@@ -205,7 +207,23 @@ Polymer({
 			));
 		}
 	},
-	_getInputClass: function(tri) {
-		return tri ? 'tri' : '';
+	_setIndeterminate: function(newValue) {
+		var elem = this.$$('input');
+		if (newValue) {
+			elem.indeterminate = true;
+			elem.setAttribute('aria-checked', 'mixed');
+		} else {
+			elem.indeterminate = false;
+			elem.removeAttribute('aria-checked');
+		}
+		console.log(this.indeterminate);
+		const browserType = window.navigator.userAgent;
+		if (this.indeterminate && (browserType.indexOf('Trident') > -1 || browserType.indexOf('Edge') > -1)) {
+			console.log('in here');
+			this.dispatchEvent(new CustomEvent(
+				'change',
+				{bubbles: true, composed: false}
+			));
+		}
 	}
 });

--- a/d2l-input-checkbox.js
+++ b/d2l-input-checkbox.js
@@ -197,9 +197,9 @@ Polymer({
 			{bubbles: true, composed: false}
 		));
 	},
-	_onClick: function(e) {
+	_onClick: function() {
 		const browserType = window.navigator.userAgent;
-		if ( this.indeterminate && (browserType.indexOf('Trident') > -1 || browserType.indexOf('Edge') > -1)) {
+		if (this.indeterminate && (browserType.indexOf('Trident') > -1 || browserType.indexOf('Edge') > -1)) {
 			this.checked = !this.checked;
 			this.indeterminate = false;
 			this.dispatchEvent(new CustomEvent(

--- a/d2l-input-checkbox.js
+++ b/d2l-input-checkbox.js
@@ -105,7 +105,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-input-checkbox">
 			}
 		</style>
 		<label>
-			<input type="checkbox" class$="[[_getInputClass(tri)]]" aria-label$="[[ariaLabel]]" aria-labelledby$="[[ariaLabelledby]]" checked="{{checked}}" disabled$="[[disabled]]" name$="[[name]]" on-change="_handleChange" on-click="_onClick" on-focus="_handleFocus" value$="[[value]]">
+			<input type="checkbox" aria-label$="[[ariaLabel]]" aria-labelledby$="[[ariaLabelledby]]" checked="{{checked}}" disabled$="[[disabled]]" name$="[[name]]" on-change="_handleChange" on-click="_handleClick" on-focus="_handleFocus" value$="[[value]]">
 			<span class="d2l-input-checkbox-label"><slot></slot></span>
 		</label>
 	</template>
@@ -197,7 +197,12 @@ Polymer({
 			{bubbles: true, composed: false}
 		));
 	},
-	_onClick: function() {
+	/**
+	 * This is needed only for IE11 and Edge AND going from indeterminate to checked/unchecked. 
+	 * When the indeterminate state is set, and the checkbox is clicked, the _handleChange 
+	 * function is NOT triggered, therefore we have to detect the click and handle it ourselves.
+	 */
+	_handleClick: function() {
 		const browserType = window.navigator.userAgent;
 		if (this.indeterminate && (browserType.indexOf('Trident') > -1 || browserType.indexOf('Edge') > -1)) {
 			this.checked = !this.checked;

--- a/demo/d2l-input-checkbox.html
+++ b/demo/d2l-input-checkbox.html
@@ -97,6 +97,13 @@ $_documentContainer.innerHTML = `<div class="vertical-section-container centered
 				</template>
 			</demo-snippet>
 
+			<h3>Indeterminate checkbox</h3>
+			<demo-snippet>
+				<template>
+					<d2l-input-checkbox checked indeterminate>Indeterminate checkbox</d2l-input-checkbox>
+				</template>
+			</demo-snippet>
+
 		</div>`;
 
 document.body.appendChild($_documentContainer.content);

--- a/test/d2l-input-checkbox.html
+++ b/test/d2l-input-checkbox.html
@@ -20,6 +20,16 @@
 				<d2l-input-checkbox checked label="checked"></d2l-input-checkbox>
 			</template>
 		</test-fixture>
+		<test-fixture id="indeterminate-checked">
+			<template>
+				<d2l-input-checkbox indeterminate checked label="indeterminate-checked"></d2l-input-checkbox>
+			</template>
+		</test-fixture>
+		<test-fixture id="indeterminate-unchecked">
+			<template>
+				<d2l-input-checkbox indeterminate label="indeterminate-unchecked"></d2l-input-checkbox>
+			</template>
+		</test-fixture>
 		<test-fixture id="disabled">
 			<template>
 				<d2l-input-checkbox disabled label="disabled"></d2l-input-checkbox>
@@ -149,6 +159,128 @@ describe('d2l-input-checkbox', function() {
 
 		});
 
+	});
+
+	describe('indeterminate', function() {
+		describe('indeterminate-checked', function() {
+
+			beforeEach(function() {
+				elem = fixture('indeterminate-checked');
+			});
+
+			it('should default "checked" and "indeterminate" to true', function() {
+				expect(elem.checked).to.be.true;
+				expect(elem.indeterminate).to.be.true;
+				expect(elem.hasAttribute('checked')).to.be.true;
+				expect(elem.hasAttribute('indeterminate')).to.be.true;
+				expect(elem.$$('input').checked).to.be.true;
+			});
+
+			it('should reflect "checked" and "indeterminate" property change to attribute and input', function() {
+				elem.checked = false;
+				expect(elem.hasAttribute('checked')).to.be.false;
+				expect(elem.hasAttribute('indeterminate')).to.be.true;
+				expect(elem.$$('input').checked).to.be.false;
+			});
+
+			it('should reflect input "checked" and "indeterminate" change to attribute and property', function() {
+				elem.$$('input').click();
+				expect(elem.checked).to.be.false;
+				expect(elem.indeterminate).to.be.false;
+				expect(elem.hasAttribute('checked')).to.be.false;
+				expect(elem.hasAttribute('indeterminate')).to.be.false;
+			});
+			it('should fire "change" event when input element is clicked', function(done) {
+				var input = elem.$$('input');
+				elem.addEventListener('change', function(e) {
+					expect(e.target.checked).to.equal(false);
+					expect(e.target.indeterminate).to.equal(false);
+					done();
+				});
+				MockInteractions.tap(input);
+			});
+
+		});
+		describe('indeterminate-unchecked', function() {
+
+			beforeEach(function() {
+				elem = fixture('indeterminate-unchecked');
+			});
+
+			it('should default "checked" to false and "indeterminate" to true', function() {
+				expect(elem.checked).to.be.false;
+				expect(elem.indeterminate).to.be.true;
+				expect(elem.hasAttribute('checked')).to.be.false;
+				expect(elem.hasAttribute('indeterminate')).to.be.true;
+				expect(elem.$$('input').checked).to.be.false;
+			});
+
+			it('should reflect "checked" and "indeterminate" property change to attribute and input', function() {
+				elem.checked = true;
+				expect(elem.hasAttribute('checked')).to.be.true;
+				expect(elem.hasAttribute('indeterminate')).to.be.true;
+				expect(elem.$$('input').checked).to.be.true;
+			});
+
+			it('should reflect input "checked" and "indeterminate" change to attribute and property', function() {
+				elem.$$('input').click();
+				expect(elem.checked).to.be.true;
+				expect(elem.indeterminate).to.be.false;
+				expect(elem.hasAttribute('checked')).to.be.true;
+				expect(elem.hasAttribute('indeterminate')).to.be.false;
+			});
+			it('should fire "change" event when input element is clicked', function(done) {
+				var input = elem.$$('input');
+				elem.addEventListener('change', function(e) {
+					expect(e.target.checked).to.equal(true);
+					expect(e.target.indeterminate).to.equal(false);
+					done();
+				});
+				MockInteractions.tap(input);
+			});
+		});
+		describe('set indeterminate from unchecked', function() {
+
+			beforeEach(function() {
+				elem = fixture('basic');
+			});
+
+			it('should reflect input "indeterminate" change to attribute and property', function() {
+				elem.indeterminate = true;
+				expect(elem.checked).to.be.false;
+				expect(elem.indeterminate).to.be.true;
+				expect(elem.hasAttribute('checked')).to.be.false;
+				expect(elem.hasAttribute('indeterminate')).to.be.true;
+			});
+			it('should reflect input "indeterminate" change to attribute and property', function() {
+				elem.setAttribute('indeterminate', true);
+				expect(elem.checked).to.be.false;
+				expect(elem.indeterminate).to.be.true;
+				expect(elem.hasAttribute('checked')).to.be.false;
+				expect(elem.hasAttribute('indeterminate')).to.be.true;
+			});
+		});
+		describe('set indeterminate from checked', function() {
+
+			beforeEach(function() {
+				elem = fixture('checked');
+			});
+
+			it('should reflect input "indeterminate" change to attribute and property', function() {
+				elem.indeterminate = true;
+				expect(elem.checked).to.be.true;
+				expect(elem.indeterminate).to.be.true;
+				expect(elem.hasAttribute('checked')).to.be.true;
+				expect(elem.hasAttribute('indeterminate')).to.be.true;
+			});
+			it('should reflect input "indeterminate" change to attribute and property', function() {
+				elem.setAttribute('indeterminate', true);
+				expect(elem.checked).to.be.true;
+				expect(elem.indeterminate).to.be.true;
+				expect(elem.hasAttribute('checked')).to.be.true;
+				expect(elem.hasAttribute('indeterminate')).to.be.true;
+			});
+		});
 	});
 
 	describe('disabled', function() {


### PR DESCRIPTION
This is an attempt to add an indeterminate state to the checkbox component. The _handleChange function ensures that the indeterminate state is removed. However, in IE11 and Edge, _handleChange is not called, so I had to detect a click, and change it "manually" from indeterminate to not, as well as trigger the checked state.
Please let me know if there's a more elegant way I can do this!