### PR TITLE
US102877: add tabindex property

### DIFF
--- a/d2l-input-checkbox.js
+++ b/d2l-input-checkbox.js
@@ -105,7 +105,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-input-checkbox">
 			}
 		</style>
 		<label>
-			<input type="checkbox" aria-label$="[[ariaLabel]]" aria-labelledby$="[[ariaLabelledby]]" checked="{{checked}}" disabled$="[[disabled]]" name$="[[name]]" on-change="_handleChange" on-click="_handleClick" on-focus="_handleFocus" value$="[[value]]">
+			<input type="checkbox" aria-label$="[[ariaLabel]]" aria-labelledby$="[[ariaLabelledby]]" checked="{{checked}}" disabled$="[[disabled]]" name$="[[name]]" on-change="_handleChange" on-click="_handleClick" on-focus="_handleFocus" value$="[[value]]" tabindex$="[[tabindex]]">
 			<span class="d2l-input-checkbox-label"><slot></slot></span>
 		</label>
 	</template>
@@ -160,6 +160,13 @@ Polymer({
 			reflectToAttribute: true,
 			value: false,
 			observer: '_setIndeterminate'
+		},
+		/**
+		 * Gets or sets the tabindex attribute
+		 */
+		tabindex: {
+			type: Number,
+			reflectToAttribute: true
 		},
 		/**
 		 * Gets or sets the disabled state of the checkbox, `true` is disabled and `false` is enabled.

--- a/d2l-input-checkbox.js
+++ b/d2l-input-checkbox.js
@@ -165,8 +165,7 @@ Polymer({
 		 * Gets or sets the tabindex attribute
 		 */
 		tabindex: {
-			type: Number,
-			reflectToAttribute: true
+			type: Number
 		},
 		/**
 		 * Gets or sets the disabled state of the checkbox, `true` is disabled and `false` is enabled.

--- a/test/d2l-input-checkbox.html
+++ b/test/d2l-input-checkbox.html
@@ -40,6 +40,11 @@
 				<d2l-input-checkbox name="cb-name" value="cb-value" label="name-value"></d2l-input-checkbox>
 			</template>
 		</test-fixture>
+		<test-fixture id="tabindex">
+			<template>
+				<d2l-input-checkbox tabindex="-1" label="tabindex"></d2l-input-checkbox>
+			</template>
+		</test-fixture>
 		<script type="module">
 import '@polymer/iron-test-helpers/mock-interactions.js';
 import '../d2l-input-checkbox.js';
@@ -447,6 +452,61 @@ describe('d2l-input-checkbox', function() {
 				expect(elem.$$('input').name).to.equal('new name');
 			});
 
+		});
+
+	});
+
+	describe('tabindex', function() {
+
+		describe('default', function() {
+
+			beforeEach(function() {
+				elem = fixture('basic');
+			});
+
+			it('should default "tabindex" to undefined', function() {
+				expect(elem.tabindex).to.equal(undefined);
+				expect(elem.$$('input').tabindex).to.equal(undefined);
+				expect(elem.getAttribute('tabindex')).to.equal(null);
+			});
+
+			it('should reflect "tabindex" property change to attribute and input', function() {
+				elem.tabindex = '-1';
+				expect(elem.getAttribute('tabindex')).to.equal('-1');
+				expect(elem.$$('input').tabIndex).to.equal(-1);
+			});
+
+			it('should reflect "tabindex" attribute change to property and input', function() {
+				elem.setAttribute('tabindex', '-1');
+				expect(elem.tabindex).to.equal(-1);
+				expect(elem.$$('input').tabIndex).to.equal(-1);
+			});
+
+		});
+
+		describe('set', function() {
+
+			beforeEach(function() {
+				elem = fixture('tabindex');
+			});
+
+			it('should set "tabindex" to "-1"', function() {
+				expect(elem.tabindex).to.equal(-1);
+				expect(elem.getAttribute('tabindex')).to.equal('-1');
+				expect(elem.$$('input').tabIndex).to.equal(-1);
+			});
+
+			it('should reflect "tabindex" property change to attribute and input', function() {
+				elem.tabindex = '1';
+				expect(elem.getAttribute('tabindex')).to.equal('1');
+				expect(elem.$$('input').tabIndex).to.equal(1);
+			});
+
+			it('should reflect "tabindex" attribute change to property and input', function() {
+				elem.setAttribute('tabindex', '1');
+				expect(elem.tabindex).to.equal(1);
+				expect(elem.$$('input').tabIndex).to.equal(1);
+			});
 		});
 
 	});

--- a/test/d2l-input-checkbox.html
+++ b/test/d2l-input-checkbox.html
@@ -470,12 +470,6 @@ describe('d2l-input-checkbox', function() {
 				expect(elem.getAttribute('tabindex')).to.equal(null);
 			});
 
-			it('should reflect "tabindex" property change to attribute and input', function() {
-				elem.tabindex = '-1';
-				expect(elem.getAttribute('tabindex')).to.equal('-1');
-				expect(elem.$$('input').tabIndex).to.equal(-1);
-			});
-
 			it('should reflect "tabindex" attribute change to property and input', function() {
 				elem.setAttribute('tabindex', '-1');
 				expect(elem.tabindex).to.equal(-1);
@@ -494,12 +488,6 @@ describe('d2l-input-checkbox', function() {
 				expect(elem.tabindex).to.equal(-1);
 				expect(elem.getAttribute('tabindex')).to.equal('-1');
 				expect(elem.$$('input').tabIndex).to.equal(-1);
-			});
-
-			it('should reflect "tabindex" property change to attribute and input', function() {
-				elem.tabindex = '1';
-				expect(elem.getAttribute('tabindex')).to.equal('1');
-				expect(elem.$$('input').tabIndex).to.equal(1);
 			});
 
 			it('should reflect "tabindex" attribute change to property and input', function() {


### PR DESCRIPTION
If the <input type="checkbox"> doesn't have tabindex="-1", in IE/Edge, user can still tab to the checkbox even tabindex="-1" is specified in the <d2l-input-checkbox>. So adding tabindex property to the <input> element here. 