### PR TITLE
Fix tabindex to not requires 2 tabs to focus on checkbox

### DIFF
--- a/d2l-input-checkbox.js
+++ b/d2l-input-checkbox.js
@@ -105,7 +105,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-input-checkbox">
 			}
 		</style>
 		<label>
-			<input type="checkbox" aria-label$="[[ariaLabel]]" aria-labelledby$="[[ariaLabelledby]]" checked="{{checked}}" disabled$="[[disabled]]" name$="[[name]]" on-change="_handleChange" on-click="_handleClick" on-focus="_handleFocus" value$="[[value]]" tabindex$="[[tabIndex]]">
+			<input type="checkbox" aria-label$="[[ariaLabel]]" aria-labelledby$="[[ariaLabelledby]]" checked="{{checked}}" disabled$="[[disabled]]" name$="[[name]]" on-change="_handleChange" on-click="_handleClick" on-focus="_handleFocus" value$="[[value]]" tabindex$="[[_tabindex]]">
 			<span class="d2l-input-checkbox-label"><slot></slot></span>
 		</label>
 	</template>
@@ -162,10 +162,11 @@ Polymer({
 			observer: '_setIndeterminate'
 		},
 		/**
-		 * Gets or sets the tabIndex attribute
+		 * Gets or sets the tabbable state of the checkbox. tabbable is `true` by default.
 		 */
-		tabIndex: {
-			type: Number
+		tabbable: {
+			type: Boolean,
+			value: true
 		},
 		/**
 		 * Gets or sets the disabled state of the checkbox, `true` is disabled and `false` is enabled.
@@ -190,6 +191,10 @@ Polymer({
 			type: String,
 			reflectToAttribute: true,
 			value: 'on'
+		},
+		_tabindex: {
+			type: Number,
+			computed: '_computeTabindex(tabbable)'
 		}
 	},
 	focus: function() {
@@ -240,5 +245,8 @@ Polymer({
 			elem.removeAttribute('indeterminate');
 			elem.removeAttribute('aria-checked');
 		}
+	},
+	_computeTabindex: function(tabbable) {
+		return tabbable ? 0 : -1;
 	}
 });

--- a/d2l-input-checkbox.js
+++ b/d2l-input-checkbox.js
@@ -162,7 +162,7 @@ Polymer({
 			observer: '_setIndeterminate'
 		},
 		/**
-		 * Gets or sets the not-tabbable state of the checkbox. `true` is not-tabbable and false` is tabbable.
+		 * Gets or sets the not-tabbable state of the checkbox. `true` is not-tabbable and `false` is tabbable.
 		 */
 		notTabbable: {
 			type: Boolean,

--- a/d2l-input-checkbox.js
+++ b/d2l-input-checkbox.js
@@ -105,7 +105,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-input-checkbox">
 			}
 		</style>
 		<label>
-			<input type="checkbox" aria-label$="[[ariaLabel]]" aria-labelledby$="[[ariaLabelledby]]" checked="{{checked}}" disabled$="[[disabled]]" name$="[[name]]" on-change="_handleChange" on-click="_handleClick" on-focus="_handleFocus" value$="[[value]]" tabindex$="[[tabindex]]">
+			<input type="checkbox" aria-label$="[[ariaLabel]]" aria-labelledby$="[[ariaLabelledby]]" checked="{{checked}}" disabled$="[[disabled]]" name$="[[name]]" on-change="_handleChange" on-click="_handleClick" on-focus="_handleFocus" value$="[[value]]" tabindex$="[[tabIndex]]">
 			<span class="d2l-input-checkbox-label"><slot></slot></span>
 		</label>
 	</template>
@@ -162,9 +162,9 @@ Polymer({
 			observer: '_setIndeterminate'
 		},
 		/**
-		 * Gets or sets the tabindex attribute
+		 * Gets or sets the tabIndex attribute
 		 */
-		tabindex: {
+		tabIndex: {
 			type: Number
 		},
 		/**

--- a/d2l-input-checkbox.js
+++ b/d2l-input-checkbox.js
@@ -162,11 +162,11 @@ Polymer({
 			observer: '_setIndeterminate'
 		},
 		/**
-		 * Gets or sets the tabbable state of the checkbox. tabbable is `true` by default.
+		 * Gets or sets the not-tabbable state of the checkbox. `true` is not-tabbable and false` is tabbable.
 		 */
-		tabbable: {
+		notTabbable: {
 			type: Boolean,
-			value: true
+			value: false
 		},
 		/**
 		 * Gets or sets the disabled state of the checkbox, `true` is disabled and `false` is enabled.
@@ -194,7 +194,7 @@ Polymer({
 		},
 		_tabindex: {
 			type: Number,
-			computed: '_computeTabindex(tabbable)'
+			computed: '_computeTabindex(notTabbable)'
 		}
 	},
 	focus: function() {
@@ -246,7 +246,7 @@ Polymer({
 			elem.removeAttribute('aria-checked');
 		}
 	},
-	_computeTabindex: function(tabbable) {
-		return tabbable ? 0 : -1;
+	_computeTabindex: function(notTabbable) {
+		return notTabbable ? -1 : 0;
 	}
 });

--- a/test/d2l-input-checkbox.html
+++ b/test/d2l-input-checkbox.html
@@ -42,7 +42,7 @@
 		</test-fixture>
 		<test-fixture id="tabindex">
 			<template>
-				<d2l-input-checkbox tabindex="-1" label="tabindex"></d2l-input-checkbox>
+				<d2l-input-checkbox tab-index="-1" label="tabindex"></d2l-input-checkbox>
 			</template>
 		</test-fixture>
 		<script type="module">
@@ -465,14 +465,14 @@ describe('d2l-input-checkbox', function() {
 			});
 
 			it('should default "tabindex" to undefined', function() {
-				expect(elem.tabindex).to.equal(undefined);
-				expect(elem.$$('input').tabindex).to.equal(undefined);
-				expect(elem.getAttribute('tabindex')).to.equal(null);
+				expect(elem.tabIndex).to.equal(undefined);
+				expect(elem.$$('input').tabIndex).to.equal(0);
+				expect(elem.getAttribute('tab-index')).to.equal(null);
 			});
 
 			it('should reflect "tabindex" attribute change to property and input', function() {
-				elem.setAttribute('tabindex', '-1');
-				expect(elem.tabindex).to.equal(-1);
+				elem.setAttribute('tab-index', '-1');
+				expect(elem.getAttribute('tab-index')).to.equal('-1');
 				expect(elem.$$('input').tabIndex).to.equal(-1);
 			});
 
@@ -485,14 +485,13 @@ describe('d2l-input-checkbox', function() {
 			});
 
 			it('should set "tabindex" to "-1"', function() {
-				expect(elem.tabindex).to.equal(-1);
-				expect(elem.getAttribute('tabindex')).to.equal('-1');
+				expect(elem.getAttribute('tab-index')).to.equal('-1');
 				expect(elem.$$('input').tabIndex).to.equal(-1);
 			});
 
 			it('should reflect "tabindex" attribute change to property and input', function() {
-				elem.setAttribute('tabindex', '1');
-				expect(elem.tabindex).to.equal(1);
+				elem.setAttribute('tab-index', '1');
+				expect(elem.getAttribute('tab-index')).to.equal('1');
 				expect(elem.$$('input').tabIndex).to.equal(1);
 			});
 		});

--- a/test/d2l-input-checkbox.html
+++ b/test/d2l-input-checkbox.html
@@ -40,6 +40,11 @@
 				<d2l-input-checkbox name="cb-name" value="cb-value" label="name-value"></d2l-input-checkbox>
 			</template>
 		</test-fixture>
+		<test-fixture id="not-tabbable">
+			<template>
+				<d2l-input-checkbox not-tabbable="not-tabbable" label="not-tabbable"></d2l-input-checkbox>
+			</template>
+		</test-fixture>
 		<script type="module">
 import '@polymer/iron-test-helpers/mock-interactions.js';
 import '../d2l-input-checkbox.js';
@@ -451,7 +456,7 @@ describe('d2l-input-checkbox', function() {
 
 	});
 
-	describe('tabbable', function() {
+	describe('not-tabbable', function() {
 
 		describe('default', function() {
 
@@ -459,15 +464,21 @@ describe('d2l-input-checkbox', function() {
 				elem = fixture('basic');
 			});
 
-			it('should default "tabbable" to true', function() {
-				expect(elem.tabbable).to.equal(true);
+			it('should default "not-tabbable" to undefined', function() {
+				expect(elem.notTabbable).to.be.false;
 				expect(elem.$$('input').tabIndex).to.equal(0);
-				expect(elem.getAttribute('tabbable')).to.equal(null);
+				expect(elem.hasAttribute('not-tabbable')).to.be.false;
 			});
 
-			it('should reflect "tabbable" property change and "tabindex" attribute change to input', function() {
-				elem.tabbable = false;
-				expect(elem.tabbable).to.equal(false);
+			it('should reflect "not-tabbable" property change to property and input', function() {
+				elem.notTabbable = true;
+				expect(elem.notTabbable).to.be.true;
+				expect(elem.$$('input').tabIndex).to.equal(-1);
+			});
+
+			it('should reflect "not-tabbable" attribute change to property and input', function() {
+				elem.setAttribute('not-tabbable', 'not-tabbable');
+				expect(elem.notTabbable).to.be.true;
 				expect(elem.$$('input').tabIndex).to.equal(-1);
 			});
 
@@ -476,18 +487,24 @@ describe('d2l-input-checkbox', function() {
 		describe('set', function() {
 
 			beforeEach(function() {
-				elem = fixture('basic');
-				elem.tabbable = false;
+				elem = fixture('not-tabbable');
 			});
 
-			it('should set "tabbable" to "false"', function() {
-				expect(elem.getAttribute('tabbable')).to.equal(null);
+			it('should set "not-tabbable" to true', function() {
+				expect(elem.notTabbable).to.be.true;
+				expect(elem.hasAttribute('not-tabbable')).to.be.true;
 				expect(elem.$$('input').tabIndex).to.equal(-1);
 			});
 
-			it('should reflect "tabbable" attribute change to property and input', function() {
-				elem.setAttribute('tabbable', false);
-				expect(elem.tabbable).to.equal(true);
+			it('should reflect "not-tabbable" property change to property and input', function() {
+				elem.notTabbable = false;
+				expect(elem.notTabbable).to.be.false;
+				expect(elem.$$('input').tabIndex).to.equal(0);
+			});
+
+			it('should reflect "not-tabbable" attribute change to property and input', function() {
+				elem.removeAttribute('not-tabbable');
+				expect(elem.notTabbable).to.be.false;
 				expect(elem.$$('input').tabIndex).to.equal(0);
 			});
 		});

--- a/test/d2l-input-checkbox.html
+++ b/test/d2l-input-checkbox.html
@@ -40,11 +40,6 @@
 				<d2l-input-checkbox name="cb-name" value="cb-value" label="name-value"></d2l-input-checkbox>
 			</template>
 		</test-fixture>
-		<test-fixture id="tabindex">
-			<template>
-				<d2l-input-checkbox tab-index="-1" label="tabindex"></d2l-input-checkbox>
-			</template>
-		</test-fixture>
 		<script type="module">
 import '@polymer/iron-test-helpers/mock-interactions.js';
 import '../d2l-input-checkbox.js';
@@ -456,7 +451,7 @@ describe('d2l-input-checkbox', function() {
 
 	});
 
-	describe('tabindex', function() {
+	describe('tabbable', function() {
 
 		describe('default', function() {
 
@@ -464,15 +459,15 @@ describe('d2l-input-checkbox', function() {
 				elem = fixture('basic');
 			});
 
-			it('should default "tabindex" to undefined', function() {
-				expect(elem.tabIndex).to.equal(undefined);
+			it('should default "tabbable" to true', function() {
+				expect(elem.tabbable).to.equal(true);
 				expect(elem.$$('input').tabIndex).to.equal(0);
-				expect(elem.getAttribute('tab-index')).to.equal(null);
+				expect(elem.getAttribute('tabbable')).to.equal(null);
 			});
 
-			it('should reflect "tabindex" attribute change to property and input', function() {
-				elem.setAttribute('tab-index', '-1');
-				expect(elem.getAttribute('tab-index')).to.equal('-1');
+			it('should reflect "tabbable" property change and "tabindex" attribute change to input', function() {
+				elem.tabbable = false;
+				expect(elem.tabbable).to.equal(false);
 				expect(elem.$$('input').tabIndex).to.equal(-1);
 			});
 
@@ -481,18 +476,19 @@ describe('d2l-input-checkbox', function() {
 		describe('set', function() {
 
 			beforeEach(function() {
-				elem = fixture('tabindex');
+				elem = fixture('basic');
+				elem.tabbable = false;
 			});
 
-			it('should set "tabindex" to "-1"', function() {
-				expect(elem.getAttribute('tab-index')).to.equal('-1');
+			it('should set "tabbable" to "false"', function() {
+				expect(elem.getAttribute('tabbable')).to.equal(null);
 				expect(elem.$$('input').tabIndex).to.equal(-1);
 			});
 
-			it('should reflect "tabindex" attribute change to property and input', function() {
-				elem.setAttribute('tab-index', '1');
-				expect(elem.getAttribute('tab-index')).to.equal('1');
-				expect(elem.$$('input').tabIndex).to.equal(1);
+			it('should reflect "tabbable" attribute change to property and input', function() {
+				elem.setAttribute('tabbable', false);
+				expect(elem.tabbable).to.equal(true);
+				expect(elem.$$('input').tabIndex).to.equal(0);
 			});
 		});
 

--- a/test/d2l-input-checkbox.html
+++ b/test/d2l-input-checkbox.html
@@ -464,7 +464,7 @@ describe('d2l-input-checkbox', function() {
 				elem = fixture('basic');
 			});
 
-			it('should default "not-tabbable" to undefined', function() {
+			it('should default "not-tabbable" to false', function() {
 				expect(elem.notTabbable).to.be.false;
 				expect(elem.$$('input').tabIndex).to.equal(0);
 				expect(elem.hasAttribute('not-tabbable')).to.be.false;


### PR DESCRIPTION
Problem: When tabindex is set to `0` on `d2l-input-checkbox`, both the outer `d2l-input-checkbox` and inner `input` element have `tabindex="0"`, this causes two 'tabs' to be required to focus on the checkbox in all browsers.

See example in no.2:
https://codepen.io/anon/pen/GaXbOy
