### PR TITLE
fixing search input in Safari

### DIFF
--- a/d2l-input-search.js
+++ b/d2l-input-search.js
@@ -39,6 +39,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-input-search">
 				overflow: hidden;
 				text-overflow: ellipsis;
 				white-space: nowrap;
+				-webkit-appearance: textfield;
 			}
 
 			:host(:dir(rtl)) input[type="search"].d2l-input {

--- a/d2l-input-shared-styles.js
+++ b/d2l-input-shared-styles.js
@@ -143,7 +143,8 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-input-styles">
 			textarea.d2l-input:disabled {
 				@apply --d2l-input-disabled;
 			}
-			input.d2l-input::-webkit-search-cancel-button {
+			input.d2l-input::-webkit-search-cancel-button,
+			input.d2l-input::-webkit-search-decoration {
 				display: none;
 			}
 			input.d2l-input::-ms-clear {


### PR DESCRIPTION
This is a regression from [this change](#90), which inadvertently caused search inputs in Safari to look like this:

![Screen Shot 2019-09-25 at 4 11 42 PM](https://user-images.githubusercontent.com/5491151/65636673-b7a82900-dfb0-11e9-977e-47021b224873.png)

I noticed it when testing the new Lit inputs.