### PR TITLE
GAUD-7778: remove checkbox spacer

### DIFF
--- a/d2l-input-checkbox-spacer.js
+++ b/d2l-input-checkbox-spacer.js
@@ -1,1 +1,0 @@
-import '@brightspace-ui/core/components/inputs/input-checkbox-spacer.js';

--- a/demo/d2l-input-checkbox.html
+++ b/demo/d2l-input-checkbox.html
@@ -8,7 +8,6 @@
 		<script type="module">
 			import '/node_modules/@brightspace-ui/core/components/demo/demo-page.js';
 			import '../d2l-input-checkbox.js';
-			import '../d2l-input-checkbox-spacer.js';
 		</script>
 	</head>
 	<body unresolved>
@@ -36,15 +35,6 @@
 			<h3>Disabled checkbox</h3>
 			<d2l-demo-snippet>
 				<d2l-input-checkbox checked="" disabled="">Disabled checkbox</d2l-input-checkbox>
-			</d2l-demo-snippet>
-
-			<h3>Checkbox with label and secondary content</h3>
-			<d2l-demo-snippet>
-				<d2l-input-checkbox>Label for checkbox</d2l-input-checkbox>
-				<d2l-input-checkbox-spacer style="color:#999999;">
-					Additional content can go here and will<br>
-					also line up nicely with the checkbox.
-				</d2l-input-checkbox-spacer>
 			</d2l-demo-snippet>
 
 			<h3>Indeterminate checkbox</h3>

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   "version": "4.0.0",
   "main": "d2l-inputs.js",
   "files": [
-    "d2l-input-checkbox-spacer.js",
     "d2l-input-checkbox.js",
     "d2l-input-radio-styles.js",
     "d2l-input-search.js",


### PR DESCRIPTION
We're replacing `<d2l-input-checkbox-spacer>` with a `supporting` slot on `<d2l-input-checkbox>`. I've switched all uses over to use that, opening the door to fully remove the component.

This particular usage was never used anywhere.